### PR TITLE
add qt5 and nightly packages for rhel/fedora

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -81,6 +81,12 @@ If you do not have the EPEL repositories enabled, please enable them [here](http
 sudo dnf copr enable g3tchoo/prismlauncher
 # stable releases
 sudo dnf install prismlauncher
+# latest builds
+sudo dnf install prismlauncher-nightly
+# stable Qt 5 releases
+sudo dnf install prismlauncher-qt5
+# latest Qt 5 builds
+sudo dnf install prismlauncher-qt5-nightly
 ```
 
 </div>
@@ -156,6 +162,12 @@ RPM packages are available on [Copr](https://copr.fedorainfracloud.org/coprs/g3t
 sudo dnf copr enable g3tchoo/prismlauncher
 # stable releases
 sudo dnf install prismlauncher
+# latest builds
+sudo dnf install prismlauncher-nightly
+# stable Qt 5 releases
+sudo dnf install prismlauncher-qt5
+# latest Qt 5 builds
+sudo dnf install prismlauncher-qt5-nightly
 ```
 
 ## Terra


### PR DESCRIPTION
I recently added qt5 and nightly builds to my copr repository. they will be on terra soon as well, i'll make another PR when they're ready