### PR TITLE
Fix navbar logo issues

### DIFF
--- a/src/_includes/components/header.css
+++ b/src/_includes/components/header.css
@@ -49,12 +49,6 @@ nav {
   align-items: center;
 }
 
-.home img {
-  height: 4em;
-  width: auto;
-}
-
-
 .nav-item {
   display: inline-block;
   font-size: 1.2em;

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -4,8 +4,8 @@
     <div class="navbar">
       <a class="home" href="{{ '/' | url }}" aria-label="Prism Launcher">
         <picture>
-          <source srcset="/img/logo-text.svg" media="(prefers-color-scheme: light)">
-          <img class="prismLogo" src="/img/logo-text-darkmode.svg" alt="Prism Launcher logo" />
+          <source srcset="/img/logo-text-darkmode.svg" media="(prefers-color-scheme: dark)">
+          <img class="prismLogo" src="/img/logo-text.svg" alt="Prism Launcher logo" />
         </picture>
       </a>
       <ul class="main-menu">

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -5,7 +5,7 @@
       <a class="home" href="{{ '/' | url }}" aria-label="Prism Launcher">
         <picture>
           <source srcset="/img/logo-text-darkmode.svg" media="(prefers-color-scheme: dark)">
-          <img class="prismLogo" src="/img/logo-text.svg" alt="Prism Launcher logo" />
+          <img src="/img/logo-text.svg" alt="Prism Launcher logo" style="height: 4em; width: 12em" />
         </picture>
       </a>
       <ul class="main-menu">


### PR DESCRIPTION
2abb362d7ee5f0e525c2cb5851596fb39ee1afcc:

If browsers do not tell us to prefer light mode explicitly, we should
use the light-mode logo, as the color scheme will be light mode by
default.

86df26cc00d22effca95e3524cdcb1be2044dde5:

To avoid reflowing of the navbar elements, set a fixed width for the
navbar logo as a HTML style attribute, to reserve the space as early as
possible.

See https://web.dev/optimize-cls/#images-without-dimensions