### PR TITLE
add markdown-it-table-of-contents plugin

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const pluginNavigation = require("@11ty/eleventy-navigation");
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
+const markdownItTableOfContents = require("markdown-it-table-of-contents");
 const cleanCSS = require("clean-css");
 const { EleventyRenderPlugin } = require("@11ty/eleventy");
 const Image = require("@11ty/eleventy-img");
@@ -161,7 +162,7 @@ module.exports = function (eleventyConfig) {
       level: [1, 2, 3, 4],
     }),
     slugify: eleventyConfig.getFilter("slug"),
-  });
+  }).use(markdownItTableOfContents, {"includeLevel": [1,2,3]});
   eleventyConfig.setLibrary("md", markdownLibrary);
 
   // Override Browsersync defaults (used only with --serve)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "luxon": "3.1.1",
         "markdown-it": "13.0.1",
         "markdown-it-anchor": "8.6.6",
+        "markdown-it-table-of-contents": "0.6.0",
         "markdownlint-cli": "0.32.2"
       }
     },
@@ -2603,6 +2604,15 @@
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it-table-of-contents": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz",
+      "integrity": "sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ==",
+      "dev": true,
+      "engines": {
+        "node": ">6.4.0"
       }
     },
     "node_modules/markdown-it/node_modules/argparse": {
@@ -6784,6 +6794,12 @@
       "integrity": "sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==",
       "dev": true,
       "requires": {}
+    },
+    "markdown-it-table-of-contents": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz",
+      "integrity": "sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ==",
+      "dev": true
     },
     "markdownlint": {
       "version": "0.26.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "luxon": "3.1.1",
     "markdown-it": "13.0.1",
     "markdown-it-anchor": "8.6.6",
+    "markdown-it-table-of-contents": "0.6.0",
     "markdownlint-cli": "0.32.2"
   },
   "dependencies": {


### PR DESCRIPTION
~~I have no idea how 11ty works, i want to test if this would work. need to generate a netlify preview~~

I figured it out. I would like to use this plugin (https://www.npmjs.com/package/markdown-it-table-of-contents) to generate table of content in the build instructions.

Generated Deployment from before one of the force pushes: 
![image](https://user-images.githubusercontent.com/31988415/200179754-f710c923-417e-41f5-a84b-1face44e9a46.png)
