### PR TITLE
fix wrong order and 11ty category in Overview

### DIFF
--- a/src/wiki/overview/code-of-conduct.md
+++ b/src/wiki/overview/code-of-conduct.md
@@ -2,7 +2,7 @@
 eleventyNavigation:
   key: Code of Conduct
   parent: Overview
-  order: 2
+  order: 1
 ---
 
 # Contributor Covenant Code of Conduct

--- a/src/wiki/overview/copying.md
+++ b/src/wiki/overview/copying.md
@@ -1,8 +1,8 @@
 ---
 eleventyNavigation:
   key: Copying
-  parent: Development
-  order: 2
+  parent: Overview
+  order: 5
 ---
 
 ## Prism Launcher


### PR DESCRIPTION
Copying.md had the wrong category for the folder it was in and code-of-conduct.md had the wrong order