### PR TITLE
Improvements to Controller Support wiki page

### DIFF
--- a/src/wiki/getting-started/controller-support.md
+++ b/src/wiki/getting-started/controller-support.md
@@ -11,10 +11,10 @@ This includes Steam Deck's Gamepad, PlayStation/Xbox controllers and so on.
 
 ## Before proceeding
 
-* Please ensure that you comfortable with the mod installation process within Prism Launcher.
+* Please ensure that you are comfortable with the mod installation process within Prism Launcher.
 * A full guide on this can be [found here](../download-mods/).
 * Not all game versions are supported at the time of writing, including those before 1.12.2.
-* Before proceeding, please ensure a compatible version of Java is selected. [You can learn how to do so here](../installing-java/).
+* Please ensure a compatible version of Java is selected. [You can learn how to do so here](../installing-java/).
 
 Finally, if you don't have one already, you must create an **instance** with the game version and mod loader of your choice.
 
@@ -22,40 +22,24 @@ Finally, if you don't have one already, you must create an **instance** with the
 
 Before you continue, ensure that the correct version of the **Fabric API** mod on **Fabric** or the **Quilted Fabric API** mod on **Quilt** for your instance is installed.
 
+### <img src="https://cdn-raw.modrinth.com/data/bXX9h73M/icon.svg" height="20">  MidnightControls (for Minecraft Versions 1.17 to 1.19.2)
+
+For Minecraft 1.17 to 1.19.2, we recommend [**MidnightControls**](https://modrinth.com/mod/midnightcontrols), an updated fork of LambdaControls.
+
+It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
+
 ### <img src="https://cdn-raw.modrinth.com/data/W1D3UXEc/icon.png" height="20">  LambdaControls (for Minecraft Versions 1.16.5 to 1.17.1)
 
-For Minecraft 1.16.5 to 1.17.1 we recommend the **LambdaControls** mod.
+**NOTE:** This mod is currently unmaintained and hasn't been updated since June of 2021, so unless you really need to, use MidnightControls.
 
-It can be installed using Prism Launcher's mod downloader function either with Modrinth (recommended) or CurseForge.
+For Minecraft 1.16.5 to 1.17.1, we recommend [**LambdaControls**](https://modrinth.com/mod/lambdacontrols).
 
-Once installed, please launch your instance and navigate to the in-game controls menu.
-
-Within the in-game controls menu, you may need to change the "Mode" setting to **Controller**, in order for the game to respond to input from the gamepad.
-
-Remember to get the mapping using [**the app linked in the mod**](https://generalarcade.com/gamepadtool/)
-
-### <img src="https://cdn-raw.modrinth.com/data/bXX9h73M/icon.svg" height="20">  MidnightControls (for Minecraft Versions 1.18 - 1.19.2)
-
-Since LambdaControls got deprecated, someone decided to fork it and update it.
-
-In fact, here we're recommending [MidnightControls](https://modrinth.com/mod/midnightcontrols).
-
-It's an updated fork of LambdaControls.
-
-It can be installed using Prism Launcher's mod downloader function either with Modrinth (recommended) or CurseForge.
-
-Once installed, please launch your instance and navigate to the in-game controls menu.
-
-Within the in-game controls menu, you may need to change the "Mode" setting to **Controller**, in order for the game to respond to input from the gamepad.
-
-If it doesn't work, try to get the mapping using [**the app linked in the mod**](https://generalarcade.com/gamepadtool/)
+It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
 
 ## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" height="20"> Forge
 
-### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" height="20">  Controllable (Forge)
+### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" height="20">  Controllable (for Minecraft Versions 1.12.2 to 1.19.2)
 
-For Minecraft 1.12.2 to 1.19.2 on Forge we recommend the **Controllable** mod.
+For Minecraft 1.12.2 to 1.19.2, we recommend [**Controllable**](https://www.curseforge.com/minecraft/mc-mods/controllable).
 
-Controllable can be installed using Prism Launcher's mod downloader function from the **CurseForge** service.
-
-Once installed, you may now launch your instance, and find that the mod should begin working immediately.
+Controllable can be installed using Prism Launcher's mod downloader function through CurseForge. Once installed, you may now launch your instance, and find that the mod should begin working immediately.


### PR DESCRIPTION
- Compressed a few multi line sentences into paragraphs so the reading doesn't feel as awkward
- Moved the MidnightControls section above the LambdaControls section because it's actually maintained
- Changed MidnightControls supported versions to add 1.17 (matching the [fabric.mod.json](https://github.com/TeamMidnightDust/MidnightControls/blob/9cc539370398fe8e25350e752b8eae81a77d59f3/src/main/resources/fabric.mod.json#L56))
- Added deprecation note for LambdaControls, since the only real version it should be used on is 1.16.5 
- - Since 1.17 can be handled by MidnightControls, should the 1.17 version mention be removed?
- Some other style consistency edits peppered around