### PR TITLE
Add another possible Windows 7 symptom to the troubleshooting FAQ

### DIFF
--- a/src/wiki/overview/frequent-issues.md
+++ b/src/wiki/overview/frequent-issues.md
@@ -34,9 +34,7 @@ If you are **comfortable** and **trust** Prism Launcher, then you can click on t
 
 ### <img src="https://upload.wikimedia.org/wikipedia/de/c/c2/Microsoft_Windows_7_logo.svg" height="20" /> Windows 7 and 8.1
 
-#### api-ms-win-core-synch-l1-2.0.dll not found?
-
-#### "The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll"?
+#### "api-ms-win-core-synch-l1-2.0.dll not found" or "The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll"
 
 Prism Launcher uses Qt 6 by default on Windows, which does *not* support Windows 7 and Windows 8.1.
 

--- a/src/wiki/overview/frequent-issues.md
+++ b/src/wiki/overview/frequent-issues.md
@@ -36,6 +36,8 @@ If you are **comfortable** and **trust** Prism Launcher, then you can click on t
 
 #### api-ms-win-core-synch-l1-2.0.dll not found?
 
+#### "The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll"?
+
 Prism Launcher uses Qt 6 by default on Windows, which does *not* support Windows 7 and Windows 8.1.
 
 For this reason, we still provide a build that uses Qt 5 in [our download page](https://prismlauncher.org/download/) called "Legacy version", you'll have to use that on those legacy versions of Windows.

--- a/src/wiki/overview/frequent-issues.md
+++ b/src/wiki/overview/frequent-issues.md
@@ -34,7 +34,7 @@ If you are **comfortable** and **trust** Prism Launcher, then you can click on t
 
 ### <img src="https://upload.wikimedia.org/wikipedia/de/c/c2/Microsoft_Windows_7_logo.svg" height="20" /> Windows 7 and 8.1
 
-#### "api-ms-win-core-synch-l1-2.0.dll not found" or "The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll"
+#### "api-ms-win-core-synch-l1-2.0.dll not found" or "The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll"?
 
 Prism Launcher uses Qt 6 by default on Windows, which does *not* support Windows 7 and Windows 8.1.
 


### PR DESCRIPTION
On Windows 7, `Qt6Gui.dll` can fail to load in a slightly different way from what's already in the troubleshooting guide. It seems to be looking for some Windows 10 specific DirectX functions.

This was observed in a support question on the PrismLauncher Discord:

> The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll.

In another unrelated program, this is what this error message looks like: (taken from google images, I do not own this image)

![error](https://user-images.githubusercontent.com/68424788/201501439-ab4ac99f-8abc-45b5-983e-05013d794e02.png)

The solution is to switch to the legacy download when using Win7 or Win8.1.