### PR TITLE
move windows legacy installs into download section

### DIFF
--- a/src/download/windows.md
+++ b/src/download/windows.md
@@ -11,9 +11,14 @@ eleventyNavigation:
     <div class="column">
       <div>
         <h1>Windows Download</h1>
+        <p>Windows 10/11 64bit ONLY</p>
         <br>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Setup-{{version.current}}.exe">Installer (.exe)</a>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Portable-{{version.current}}.zip">Portable (.zip)</a>
+        <p>Windows 7/8 32/64 bit</p>
+        <br>
+        <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Legacy-Setup-{{version.current}}.exe">Legacy Installer (.exe)</a>
+        <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Legacy-Portable-{{version.current}}.zip">Legacy Portable (.zip)</a>
       </div>
     </div>
     <div class="column">
@@ -23,14 +28,6 @@ eleventyNavigation:
 </div>
 
 <div class="infobox top">
-
-## Legacy version
-
-There is a legacy version of Prism Launcher, primarily for older versions of Windows like Windows 7 or Windows 8.1 and/or 32 bit Windows.
-You can download it here:
-
-- [Legacy installer (.exe)](https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Legacy-Setup-{{version.current}}.exe)
-- [Legacy portable (.zip)](https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Legacy-Portable-{{version.current}}.zip)
 
 ## Advanced Windows install options
 

--- a/src/download/windows.md
+++ b/src/download/windows.md
@@ -15,7 +15,7 @@ eleventyNavigation:
         <br>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Setup-{{version.current}}.exe">Installer (.exe)</a>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Portable-{{version.current}}.zip">Portable (.zip)</a>
-        <p>Windows 7/8 32/64 bit</p>
+        <p>Windows 7/8.1 32/64 bit and Windows 10 32 bit</p>
         <br>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Legacy-Setup-{{version.current}}.exe">Legacy Installer (.exe)</a>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-Legacy-Portable-{{version.current}}.zip">Legacy Portable (.zip)</a>


### PR DESCRIPTION
matches how macOS legacy is in download section

Signed-off-by: theofficialgman <28281419+theofficialgman@users.noreply.github.com>

We see users who don't understand that the normal windows 10/11 64bit compatible version won't run on windows 7/8. this is because we don't explicitly tell them it won't. so match the macos download page by placing this at the top