### PR TITLE
Push footer year to 2023

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,7 +1,7 @@
 <div class="footer">
     <div class="container">
         {% include "edit-on-github.njk" %}
-        © 2022 Prism Launcher Contributors
+        © 2023 Prism Launcher Contributors
         </h1>
     </div>
 </div>

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,7 +1,7 @@
 <div class="footer">
     <div class="container">
         {% include "edit-on-github.njk" %}
-        © 2023 Prism Launcher Contributors
+        © 2022,2023 Prism Launcher Contributors
         </h1>
     </div>
 </div>


### PR DESCRIPTION
This change is proposed as we near the new year of 2023, while this may be close this PR requests that it is merged at or near the start of 2023, or at the team's leisure. This change has been tested on Firefox 108 and is formatted properly. 

If there are any changes you'd like made, say for example having it be "© 2022-2023 Prism Launcher Contributors" instead of just "© 2023 Prism Launcher Contributors" or any other sort of change let me know and I'll make the requested changes. Thanks!

Signed-off-by: James Quinley <jsquinley@gmail.com>