### PR TITLE
Replace "vcredist 2022" with "Microsoft Visual C++ Redistributable 2022" on the Windows download page

### DIFF
--- a/src/download/windows.md
+++ b/src/download/windows.md
@@ -12,15 +12,15 @@ eleventyNavigation:
       <div>
         <h1>Windows Download</h1>
         <p>Windows 10/11 64bit</p>
-        <p>Requires <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">vcredist 2022 x64</a> to run</p>
+        <p>Requires <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">Microsoft Visual C++ Redistributable 2022 x64</a> to run</p>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-Setup-{{version.current}}.exe">Installer (.exe)</a>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-Portable-{{version.current}}.zip">Portable (.zip)</a>
         <p>Windows 10/11 ARM64</p>
-        <p>Requires <a href="https://aka.ms/vs/17/release/vc_redist.arm64.exe">vcredist 2022 arm64</a> to run</p>
+        <p>Requires <a href="https://aka.ms/vs/17/release/vc_redist.arm64.exe">Microsoft Visual C++ Redistributable 2022 arm64</a> to run</p>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-arm64-Setup-{{version.current}}.exe">Installer (ARM64) (.exe)</a>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-arm64-Portable-{{version.current}}.zip">Portable (ARM64) (.zip)</a>
         <p>Windows 7/8.1 32/64 bit and Windows 10 32 bit</p>
-        <p>Requires <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">vcredist 2022 x86</a> to run</p>
+        <p>Requires <a href="https://aka.ms/vs/17/release/vc_redist.x86.exe">Microsoft Visual C++ Redistributable 2022 x86</a> to run</p>
         <br>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-Legacy-Setup-{{version.current}}.exe">Installer (Legacy) (.exe)</a>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-Legacy-Portable-{{version.current}}.zip">Portable (Legacy) (.zip)</a>


### PR DESCRIPTION
Ever since around 2005, the words "Microsoft Visual C++ Redistributable" are a household name for PC users, especially for gamers. In the context of the usual computer-monkey low-level tech support, Microsoft has effectively trained their userbase to associate weird DLL errors with missing Visual C++ Redistributable. The name has been visible in the UI for ages:

![vcredist](https://user-images.githubusercontent.com/68424788/210218009-38df3d26-cc9f-4450-bbf6-ef8255be5e7f.png)

The term "vcredist", on the other hand, is gibberish for most people. Since we're linking directly to an aka.ms URL, we should use the much more recognizable URL to avoid misplaced concerns about the safety of what they're downloading. I've already see this link almost scare someone away from trying PrismLauncher, so it's probably a good idea just to make it less scary.