### PR TITLE
Update Prism Launcher Portable link

### DIFF
--- a/src/download/windows.md
+++ b/src/download/windows.md
@@ -69,6 +69,6 @@ choco install prismlauncher --package-parameters="'/legacy'"
 
 #### [PortableApps.com](https://portableapps.com) Installer
 
-A community maintained portable installer for Prism Launcher can be found [here](https://FayneAldan.github.io/PrismLauncherPortable/).
+A community maintained portable installer for Prism Launcher can be found [here](https://RuiNtD.github.io/PrismLauncherPortable/).
 
 </div>


### PR DESCRIPTION
I changed my GitHub username from FayneAldan to RuiNtD, so the link for Prism Launcher Portable broke.