### PR TITLE
fix(linux.md): remove incorrect information

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -172,8 +172,6 @@ Installing [Pacstall](https://pacstall.dev/)
 sudo bash -c "$(curl -fsSL https://git.io/JsADh || wget -q https://git.io/JsADh -O -)"
 ```
 
-NOTE: Pacstall is unstable on Debian, due to outdated dependencies.
-
 Installing Prism Launcher
 
 ```bash


### PR DESCRIPTION
We don't recommend Pacstall on Debian due to outdated dependencies for *some*, *but* that does not make Pacstall unstable