### PR TITLE
Add DeckCraft to installation page and Controller Support wiki page

### DIFF
--- a/src/download/steam-deck.md
+++ b/src/download/steam-deck.md
@@ -68,6 +68,12 @@ Head to your preferred SteamGridDB page and click on the "BOOP" button on each a
 
 That's it! You should now see the artwork in your Steam Library.
 
+### <img src="https://raw.githubusercontent.com/intergrav/Branding/main/deckcraft/mark/mark_svg.svg" height="20"> DeckCraft
+
+[DeckCraft](https://modrinth.com/project/deckcraft) is a modpack designed to make it easier to play Minecraft on the Steam Deck. It includes a variety of optimizations, extra features, pre-installed shaders, and more. It works out-of-the-box and doesn't require any manual configuration to start playing.
+
+You can install it through the launcher by heading to `Add Instance`, select the `Modrinth` tab, then press `STEAM` + `X` together to open the keyboard and search for "DeckCraft." After this, select your preferred version and install it.
+
 ### Tips and Tricks
 
 - For the best experience, go ahead and enable `Start Minecraft maximized`, and `Close Prism Launcher after game window opens` in the launcher's settings, under the `Minecraft` tab.

--- a/src/wiki/getting-started/controller-support.md
+++ b/src/wiki/getting-started/controller-support.md
@@ -36,6 +36,12 @@ For Minecraft 1.16.2 to 1.18, we recommend [**LambdaControls**](https://modrinth
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
 
+### <img src="https://raw.githubusercontent.com/intergrav/Branding/main/deckcraft/mark/mark_svg.svg" height="20"> DeckCraft (for Minecraft versions 1.18.2 or newer)
+
+If you're on the Steam Deck, [DeckCraft](https://modrinth.com/project/deckcraft) might be useful to you. This is a modpack designed to make it easier to play Minecraft on the Deck. It includes MidnightControls, various optimizations, features, configurations, pre-installed shaders, and more.
+
+You can install it through the launcher by heading to `Add Instance`, select the `Modrinth` tab, then press `STEAM` + `X` together to open the keyboard and search for "DeckCraft." After this, select your preferred version and install it.
+
 ## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" height="20"> Forge
 
 ### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" height="20">  Controllable (for Minecraft Versions 1.12.2 or newer)


### PR DESCRIPTION
![Discord screenshot of Scrumplex being epic](https://user-images.githubusercontent.com/42325132/235560790-22ec6022-18bf-49d5-adb6-26a6674faeb1.png)

This PR simply adds my modpack, [DeckCraft](https://modrinth.com/project/deckcraft), as a suggestion in both the Steam Deck installation page and Controller Support wiki page. The modpack aims to make it seamless and easy for users to install Minecraft on their Steam Deck, and includes many optimizations, features, configurations, and more.