### PR TITLE
update discord links

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -20,7 +20,7 @@
       <div class="social-links">
         <a href="https://twitter.com/PrismLauncher" target="_blank" aria-label="Twitter"><i class="fa fa-twitter"></i></a>
         <a href="https://floss.social/@PrismLauncher" target="_blank" aria-label="Mastodon" rel="me"><i class="fa fa-mastodon"></i></a>
-        <a href="https://discord.gg/prismlauncher" target="_blank" aria-label="Discord"><i class="fa fa-discord"></i></a>
+        <a href="https://discord.gg/prism-community-1031648380885147709" target="_blank" aria-label="Discord"><i class="fa fa-discord"></i></a>
         <a href="https://matrix.to/#/#prismlauncher:matrix.org" target="_blank" aria-label="Matrix"><i class="fa fa-matrix-org"></i></a>
         <a href="https://www.reddit.com/r/PrismLauncher/" target="_blank" aria-label="Reddit"><i class="fa fa-reddit"></i></a>
         <a href="https://github.com/PrismLauncher/PrismLauncher" target="_blank" aria-label="GitHub"><i class="fa fa-github"></i></a>

--- a/src/index.md
+++ b/src/index.md
@@ -90,7 +90,7 @@ hero:
 
 To talk directly to us and get involved with development:
 
-<a class="button type-link size-small" href="https://discord.gg/prismlauncher" target="_blank">Prism Launcher Discord</a>
+<a class="button type-link size-small" href="https://discord.gg/prism-community-1031648380885147709" target="_blank">Prism Launcher Discord</a>
 
 ## Matrix
 

--- a/src/welcome-channel.yaml
+++ b/src/welcome-channel.yaml
@@ -79,4 +79,4 @@
       emoji: "<:catquake:1039218794528247888>"
 
 - type: text
-  text: https://discord.gg/prismlauncher
+  text: https://discord.gg/prism-community-1031648380885147709

--- a/src/wiki/getting-started/change-themes.md
+++ b/src/wiki/getting-started/change-themes.md
@@ -68,7 +68,7 @@ Here are the instructions to get your themes & icons up and working.
 
 ### Discord Themes
 
-[![Prism Launcher Discord server](https://discordapp.com/api/guilds/1031648380885147709/widget.png?style=banner2)](https://discord.gg/prismlauncher)
+[![Prism Launcher Discord server](https://discordapp.com/api/guilds/1031648380885147709/widget.png?style=banner2)](https://discord.gg/prism-community-1031648380885147709)
 
 Instructions to install themes from Discord are located in the [#launcher-themes](https://discord.com/channels/1031648380885147709/1032673754955923598/1032673754955923598) discord channel.
 


### PR DESCRIPTION
This change uses the current permanent links for the discord, this is due to the nitro boosts expiring on the server and not having access to permanent vanity url.