### PR TITLE
better light mode support and set color-scheme

### DIFF
--- a/src/_includes/components/prism-theme.css
+++ b/src/_includes/components/prism-theme.css
@@ -15,7 +15,6 @@ pre[class*="language-"] {
   -ms-hyphens: none;
   hyphens: none;
   background: var(--code);
-  color: #f8f8f2;
 }
 
 :not(pre)>code[class*="language-"] {
@@ -119,4 +118,40 @@ pre[class*="language-"] {
 pre>code.highlight {
   outline: 0.4em solid #f92672;
   outline-offset: 0.4em;
+}
+
+@media (prefers-color-scheme: light) {
+  .token.punctuation {
+    color: #CF222E;
+  }
+  
+  .token.operator,
+  .token.boolean,
+  .token.number {
+    color: #c07016;
+  }
+
+  .token.string {
+    color: #0A338E;
+  }
+
+  .token.entity,
+  .token.url,
+  .language-css .token.string,
+  .style .token.string {
+    color: #0A338E;
+  }
+
+  .token.attr-value,
+  .token.keyword,
+  .token.control,
+  .token.directive,
+  .token.unit {
+    color: #CF222E;
+  }
+
+  .token.placeholder,
+  .token.variable {
+    color: #00afd2;
+  }
 }

--- a/src/_includes/index.css
+++ b/src/_includes/index.css
@@ -34,15 +34,20 @@
   --danger-light: hsl(17, 95%, 80%);
   
   background-color: var(--background);
+  color-scheme: dark;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
+    --code: #F6F8FA;
     --primary-text: #333;
     --primary-text-muted: #666;
     --background: #ffffff;
     --accent: #e0e0e0;
     --accent-light: #d0d0d0;
+    
+    background-color: var(--background);
+    color-scheme: light;
   }
 }
 
@@ -152,8 +157,18 @@ pre {
 
 code {
   word-break: break-all;
-  color: white;
+  color: #f8f8f2;
   background-color: var(--code);
+}
+
+:not(pre)>code {
+  padding: 0.18em;
+}
+
+@media (prefers-color-scheme: light) {
+  code {
+    color: #1F2328;
+  }
 }
 
 .highlight-line {
@@ -176,7 +191,7 @@ code {
 }
 
 .highlight-line-isdir {
-  color: #b0b0b0;
+  color: #b00808;
   background-color: #222;
 }
 


### PR DESCRIPTION
refer to https://css-tricks.com/almanac/properties/c/color-scheme/ on why prefers-color-scheme should be set so that the browser can automatically colorize native elements such as scrollbars

most colors were directly picked from github wiki automatic coloring for codeblocks as I feel a good job is done there at readability