### PR TITLE
update link to fedora rpm source repo

### DIFF
--- a/src/wiki/development/build-instructions.md
+++ b/src/wiki/development/build-instructions.md
@@ -95,8 +95,8 @@ You don't need to clone the repo for this; the spec file handles that.
 cd ~
 # setup your ~/rpmbuild directory, required for rpmbuild to work.
 rpmdev-setuptree
-# get the rpm spec file from the prismlauncher-rpm repo
-git clone https://pagure.io/prismlauncher-rpm.git
+# get the rpm spec file from the prismlauncher repo on pagure
+git clone https://pagure.io/prismlauncher.git
 cd prismlauncher-rpm
 # install build dependencies
 sudo dnf builddep prismlauncher.spec


### PR DESCRIPTION
i have recently moved from the [previous repo](https://pagure.io/prismlauncher-rpm) to a [new one](https://pagure.io/prismlauncher) that was originally intended to help the package better meet fedora's official guidelines; but now i can merge those changes into the main package. it was sent out to users
[here](https://copr.fedorainfracloud.org/coprs/g3tchoo/prismlauncher/build/5999143/)

Signed-off-by: seth <getchoo@tuta.io>
