### PR TITLE
add notice to also show system files instead of just hidden files

### DIFF
--- a/src/news/cf-compromised-alert.md
+++ b/src/news/cf-compromised-alert.md
@@ -64,7 +64,7 @@ linux users should be checking for systemd-utility.service in ~/.config/systemd/
 
 windows users should be checking for libWebGL64.jar in %localappdata%\Microsoft Edge and an entry in HKCU:\Software\Microsoft\Windows\CurrentVersion\Run or a shortcut in %appdata%\Microsoft\Windows\Start Menu\Programs\Startup and a run.bat in %localappdata%\Microsoft Edge
 
-You will need to enable "View Hidden Files" for the file to appear, if it exists. You can find guides for this online
+You will need to enable "View Hidden Files" AND "Show System Files" for the file to appear, if it exists. You can find guides for this online.
 </div>
 
 <div class="infobox top">

--- a/src/news/cf-compromised-alert.md
+++ b/src/news/cf-compromised-alert.md
@@ -64,7 +64,7 @@ linux users should be checking for systemd-utility.service in ~/.config/systemd/
 
 windows users should be checking for libWebGL64.jar in %localappdata%\Microsoft Edge and an entry in HKCU:\Software\Microsoft\Windows\CurrentVersion\Run or a shortcut in %appdata%\Microsoft\Windows\Start Menu\Programs\Startup and a run.bat in %localappdata%\Microsoft Edge
 
-You will need to enable "View Hidden Files" AND "Show System Files" for the file to appear, if it exists. You can find guides for this online.
+You will need to enable "View Hidden Files" AND disable "Hide protected operating system files" for the file to appear, if it exists. You can find guides for this online.
 </div>
 
 <div class="infobox top">


### PR DESCRIPTION
> You will need to enable "View Hidden Files" for the file to appear, if it exists. You can find guides for this online

from me quickly looking over the code, **you also need to enable "show system files" too as windows doesn't show those even if hidden files are enabled (iirc)**
i think this should maybe be mentioned in the blog post

```java
Files.setAttribute(refFile, "dos:hidden", true, new LinkOption[0]);
Files.setAttribute(refFile, "dos:system", true, new LinkOption[0]);
```