### PR TITLE
Wording Update for Script Instructions in src/news/cf-compromised-alert.md

### DIFF
--- a/src/news/cf-compromised-alert.md
+++ b/src/news/cf-compromised-alert.md
@@ -67,7 +67,7 @@ Other sandbox escapes may be possible, but the malware most likely doesn't accou
 <div class="infobox top">
 @Getchoo has released a linux and windows command line script to quickly check if these files exist:
 
-Windows:
+Windows (powershell, not cmd):
 
 ```powershell
 $appData = "$HOME\AppData"

--- a/src/news/cf-compromised-alert.md
+++ b/src/news/cf-compromised-alert.md
@@ -67,7 +67,7 @@ Other sandbox escapes may be possible, but the malware most likely doesn't accou
 <div class="infobox top">
 @Getchoo has released a linux and windows command line script to quickly check if these files exist:
 
-Windows (powershell, not cmd):
+Windows:
 
 ```powershell
 $appData = "$HOME\AppData"
@@ -101,7 +101,7 @@ Read-Host -Prompt "press any button to exit"
 ```
 
 <div class="notification type-warn">
-"To use this file, press Windows key + R, then paste and run `powershell -executionpolicy bypass -file "%UserProfile%\Downloads\check_cf.ps1"`"
+"To use this file after downloading it to your "Downloads" folder, press Windows key + R, then paste and run `powershell -executionpolicy bypass -file "%UserProfile%\Downloads\check_cf.ps1"`"
 </div>
 
 <a class="button size-medium" href="/img/news/cf-compromised/check_cf.ps1" download="check_cf.ps1">Download Windows Script</a>
@@ -136,7 +136,7 @@ fi
 ```
 
 <div class="notification type-warn">
-"To use this file, run `curl -fsSL https://prismlauncher.org/img/news/cf-compromised/check_cf.sh | bash`"
+"To automatically download and run this file, run `curl -fsSL https://prismlauncher.org/img/news/cf-compromised/check_cf.sh | bash`"
 </div>
 
 <a class="button size-medium" href="/img/news/cf-compromised/check_cf.sh" download="check_cf.sh">Download Linux Script</a>


### PR DESCRIPTION
Updates the wording in the script usage instructions for both the Linux and Windows scripts to be more accessible to people who haven't run similar scripts before. It specifies that the Linux script automatically downloads itself before running with the given command but that the Windows script has to be downloaded to the user's "Downloads" folder to be able to run by the PowerShell command given. Not sure if the increased length of the new text when compared to the old text will break formatting; probably needs to be checked.