### PR TITLE
fix: Remove bin packages from arch

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -46,16 +46,16 @@ apk add prismlauncher
 
 There are several AUR packages available:  
 [![prismlauncher](https://img.shields.io/badge/aur-prismlauncher-blue)](https://aur.archlinux.org/packages/prismlauncher/)  
-[![prismlauncher-bin](https://img.shields.io/badge/aur-prismlauncher--bin-blue)](https://aur.archlinux.org/packages/prismlauncher-bin/)  
+[![prismlauncher-qt5](https://img.shields.io/badge/aur-prismlauncher--qt5-blue)](https://aur.archlinux.org/packages/prismlauncher-qt5/)  
 [![prismlauncher-git](https://img.shields.io/badge/aur-prismlauncher--git-blue)](https://aur.archlinux.org/packages/prismlauncher-git/)
+[![prismlauncher-qt5-git](https://img.shields.io/badge/aur-prismlauncher--qt5--git-blue)](https://aur.archlinux.org/packages/prismlauncher-qt5-git/)
   
+
 ## Installing with an AUR helper
 
 ```bash
 # stable source package:
 yay -S prismlauncher
-# stable binary package:
-yay -S prismlauncher-bin
 # latest git package:
 yay -S prismlauncher-git
 ```
@@ -65,8 +65,6 @@ If you want to use Qt 5 to build the packages instead:
 ```bash
 # stable Qt 5 source package:
 yay -S prismlauncher-qt5
-# stable Qt 5 binary package:
-yay -S prismlauncher-qt5-bin
 # latest Qt 5 git package:
 yay -S prismlauncher-qt5-git
 ```

--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -50,7 +50,6 @@ There are several AUR packages available:
 [![prismlauncher-git](https://img.shields.io/badge/aur-prismlauncher--git-blue)](https://aur.archlinux.org/packages/prismlauncher-git/)
 [![prismlauncher-qt5-git](https://img.shields.io/badge/aur-prismlauncher--qt5--git-blue)](https://aur.archlinux.org/packages/prismlauncher-qt5-git/)
   
-
 ## Installing with an AUR helper
 
 ```bash
@@ -65,6 +64,8 @@ If you want to use Qt 5 to build the packages instead:
 ```bash
 # stable Qt 5 source package:
 yay -S prismlauncher-qt5
+# stable Qt 5 binary package:
+yay -S prismlauncher-qt5-bin
 # latest Qt 5 git package:
 yay -S prismlauncher-qt5-git
 ```


### PR DESCRIPTION
Removes the bin packages from the arch linux section as they are currently broken.