### PR TITLE
Update copyright year in footer

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,7 +1,7 @@
 <div class="footer">
     <div class="container">
         {% include "edit-on-github.njk" %}
-        © 2022 Prism Launcher Contributors
+        © 2022-2023 Prism Launcher Contributors
         </h1>
     </div>
 </div>


### PR DESCRIPTION
Fixed the copyright year in the footer since Prism is still maintained.