### PR TITLE
Spell-check in OpenSUSE section of download page

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -224,7 +224,7 @@ RPM packages are available on the [Open Build Service](https://download.opensuse
   
 ```bash
 # add repository (if on leap, replace 'openSUSE_Tumbleweed' with '15.4')
-zypper addrepo https://download.opensuse.org/repositories/home:getchoo/openSUSE_Tumbleweed/home:getchoo.repo
+zypper addrepo https://download.opensuse.org/repositories/home:getchoo/openSUSE_Tumbleweed/ prism-mc-launcher
 # refresh repository cache
 zypper refresh
 # stable releases (Qt6 version, only for Tumbleweed)
@@ -233,7 +233,7 @@ zypper install prismlauncher
 zypper install prismlauncher-nightly
 # stable releases (Qt5 version, available for Leap and Tumbleweed)
 zypper install prismlauncher-qt5
-# latest builds (avalible for Leap and Tumbleweed)
+# latest builds (available for Leap and Tumbleweed)
 zypper install prismlauncher-qt5-nightly
 ```
   

--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -224,7 +224,7 @@ RPM packages are available on the [Open Build Service](https://download.opensuse
   
 ```bash
 # add repository (if on leap, replace 'openSUSE_Tumbleweed' with '15.4')
-zypper addrepo https://download.opensuse.org/repositories/home:getchoo/openSUSE_Tumbleweed/
+zypper addrepo https://download.opensuse.org/repositories/home:getchoo/openSUSE_Tumbleweed/home:getchoo.repo
 # refresh repository cache
 zypper refresh
 # stable releases (Qt6 version, only for Tumbleweed)

--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -224,7 +224,7 @@ RPM packages are available on the [Open Build Service](https://download.opensuse
   
 ```bash
 # add repository (if on leap, replace 'openSUSE_Tumbleweed' with '15.4')
-zypper addrepo https://download.opensuse.org/repositories/home:getchoo/openSUSE_Tumbleweed/ prism-mc-launcher
+zypper addrepo https://download.opensuse.org/repositories/home:getchoo/openSUSE_Tumbleweed/
 # refresh repository cache
 zypper refresh
 # stable releases (Qt6 version, only for Tumbleweed)


### PR DESCRIPTION
Changed URL so that Zypper is happy. Added an alias so that it's obvious that this repo is for Prism Launcher.