### PR TITLE
Update welcome-channel.yaml with new rule.

### DIFF
--- a/src/welcome-channel.yaml
+++ b/src/welcome-channel.yaml
@@ -20,7 +20,7 @@
     Follow the given channel topic: Don't derail a discussion, and don't start conversations outside of the channel in which they're most appropriate. For example, if you start to get off-topic in an on-topic channel, ask other participants to move to an off-topic channels. Advertisements are not allowed outside of showcase channels.
     Don't import drama or controversy from other communities: In these topics, emotions run high and opinions run even higher. To avoid arguments and other similar problems, simply avoid discussion of controversial topics from other communities.
     Do not misuse accessibility tools: "[PluralKit](https://pluralkit.me) is here as aid for self identification purposes. Role-playing with PluralKit is not allowed."
-    No support for custom clients & cheats: We do not provide support for issues caused by custom clients, cheats, and external installers (e.g. installer for custom client or cheat) or how to install custom clients and cheats. For support ask their respective developers.
+    No support for custom clients & cheats: We do not provide support for issues caused by or the usage of custom clients, cheats, and external installers (e.g. installer for custom client or cheat). Ask their respective developers.
     Do not ping staff members for support requests: Our moderators are not supporters! All support is done voluntarily. People might not know how to fix your problem, if no one has responded to your request for a long time.
 
 - type: links

--- a/src/welcome-channel.yaml
+++ b/src/welcome-channel.yaml
@@ -20,6 +20,7 @@
     Follow the given channel topic: Don't derail a discussion, and don't start conversations outside of the channel in which they're most appropriate. For example, if you start to get off-topic in an on-topic channel, ask other participants to move to an off-topic channels. Advertisements are not allowed outside of showcase channels.
     Don't import drama or controversy from other communities: In these topics, emotions run high and opinions run even higher. To avoid arguments and other similar problems, simply avoid discussion of controversial topics from other communities.
     Do not misuse accessibility tools: "[PluralKit](https://pluralkit.me) is here as aid for self identification purposes. Role-playing with PluralKit is not allowed."
+    No support for custom clients & cheats: We do not provide support for issues caused by custom clients, cheats, and external installers (e.g. installer for custom client or cheat) or how to install custom clients and cheats. For support ask their respective developers.
     Do not ping staff members for support requests: Our moderators are not supporters! All support is done voluntarily. People might not know how to fix your problem, if no one has responded to your request for a long time.
 
 - type: links


### PR DESCRIPTION
This change adds a rule about support for custom clients and cheats. Many of these have custom ways to install them using external installers prism does not work with. 