### PR TITLE
chore: remove qt5 builds from fedora download

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -110,10 +110,6 @@ sudo dnf copr enable g3tchoo/prismlauncher
 sudo dnf install prismlauncher
 # nightly builds
 sudo dnf install prismlauncher-nightly
-# stable Qt 5 releases
-sudo dnf install prismlauncher-qt5
-# nightly Qt 5 builds
-sudo dnf install prismlauncher-qt5-nightly
 ```
 
 </div>


### PR DESCRIPTION
A part of https://github.com/PrismLauncher/PrismLauncher/issues/2324

I have disabled builds for Qt 5 on Fedora 40/rawhide as they no longer ship Qt 5. This is also being done in other repositories https://github.com/terrapkg/packages/pull/1111