### PR TITLE
Update build-instructions-openbsd.md

### DIFF
--- a/src/wiki/development/build-instructions-openbsd.md
+++ b/src/wiki/development/build-instructions-openbsd.md
@@ -23,18 +23,18 @@ cd PrismLauncher
 
 ## Building
 
-Tested on OpenBSD 7.0-alpha i386. It should also work on older versions.
+Tested on OpenBSD 7.5 amd64. It should also work on older versions.
 
 ### Build dependencies
 
 - A C++ compiler capable of building C++11 code (included in base system).
-- Qt Development tools 5.12 or newer ([meta/qt5](https://openports.se/meta/qt5)).
-- cmake 3.1 or newer ([devel/cmake](https://openports.se/devel/cmake)).
-- extra-cmake-modules ([devel/kf5/extra-cmake-modules](https://openports.se/devel/kf5/extra-cmake-modules))
+- Qt Development tools 6.6 or newer ([meta/qt6](https://openports.pl/meta/qt6)).
+- cmake 3.1 or newer ([devel/cmake](https://openports.pl/devel/cmake)).
+- extra-cmake-modules ([devel/kf5/extra-cmake-modules](https://openports.pl/devel/kf5/extra-cmake-modules))
 - zlib (included in base system).
-- Java JDK ([devel/jdk-1.8](https://openports.se/devel/jdk/1.8)).
+- Java JDK ([devel/jdk-1.8](https://openports.pl/devel/jdk/1.8)).
 - GL headers (included in base system).
-- lwjgl ([games/lwjgl](https://openports.se/games/lwjgl) and [games/lwjgl3](https://openports.se/games/lwjgl3)).
+- lwjgl ([games/lwjgl](https://openports.pl/games/lwjgl) and [games/lwjgl3](https://openports.pl/games/lwjgl3)).
 
 You can use IDEs, like KDevelop or QtCreator, to open the CMake project if you want to work on the code.
 
@@ -44,7 +44,7 @@ You can use IDEs, like KDevelop or QtCreator, to open the CMake project if you w
 mkdir install
 # configure the project
 cmake -S . -B build \
-   -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_PREFIX_PATH=/usr/local/lib/qt5/cmake -DENABLE_LTO=ON
+   -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_PREFIX_PATH=/usr/local/lib/qt6/cmake -DENABLE_LTO=ON
 # build
 cd build
 make -j$(nproc) install
@@ -60,9 +60,9 @@ This is the preferred method of installation, and is suitable for packages.
 cmake -S . -B build \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="/usr/local" \ # /usr/local is default in OpenBSD and FreeBSD
-   -DCMAKE_PREFIX_PATH=/usr/local/lib/qt5/cmake # use linux layout and point to qt5 libs
+   -DCMAKE_PREFIX_PATH=/usr/local/lib/qt6/cmake # use linux layout and point to qt5 libs
    -DENABLE_LTO=ON # if you want to enable LTO/IPO
-   -DLauncher_QT_VERSION_MAJOR="5"
+   -DLauncher_QT_VERSION_MAJOR="6"
 cd build
 make -j$(nproc) install # Optionally specify DESTDIR for packages (i.e. DESTDIR=${pkgdir})
 ```


### PR DESCRIPTION
Switch openbsd instructions to qt6 as it appears to work fine.

Still need to test mc itself on metal since this was in a vm so leaving as a draft for now.

Goal longterm is to maintain an actual prismlauncher package for openbsd