### PR TITLE
fix `Support Prism Launcher` link

### DIFF
--- a/src/successful-login.njk
+++ b/src/successful-login.njk
@@ -14,7 +14,7 @@ hero:
         </div>
       </div>
       <div class="row" style="flex-direction:column;gap:1em;">
-        <a class="button size-large fullwidth type-link" href="https://flathub.org/apps/details/org.prismlauncher.PrismLauncher" target="_blank">Support Prism Launcher</a>
+        <a class="button size-large fullwidth type-link" href="https://opencollective.com/prismlauncher" target="_blank">Support Prism Launcher</a>
         <a class="button size-large fullwidth type-info" href="https://prismlauncher.org/wiki/getting-started/">Getting Started Guide</a>
       </div>
     </div>


### PR DESCRIPTION
fixes the `Support Prism Launcher` button from https://prismlauncher.org/successful-login/ redirecting to flathub, was it telling everyone to support prism by switching to linux lol /j