### PR TITLE
Add missing build dependency for Qt5

### DIFF
--- a/src/wiki/development/build-instructions/linux.md
+++ b/src/wiki/development/build-instructions/linux.md
@@ -29,7 +29,7 @@ Getting the project to build and run on Linux is easy if you use any modern and 
 
 - A C++ compiler capable of building C++17 code.
 - Qt Development tools 6.0 or newer (`qt6-base-dev qtchooser qt6-base-dev-tools libqt6core6 libqt6core5compat6-dev libqt6network6` on Debian (testing/unstable) based systems).
-- Alternatively, you can also use Qt 5.12 or newer (`qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5` on Debian-based systems), if you prefer it.
+- Alternatively, you can also use Qt 5.12 or newer (`qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5 libqt5networkauth5-dev` on Debian-based systems), if you prefer it.
 - cmake 3.15 or newer (`cmake` on Debian-based system)
 - ninja (`ninja-build` on Debian-based systems)
 - extra-cmake-modules (`extra-cmake-modules` on Debian-based system)


### PR DESCRIPTION
Add libqt5networkauth5-dev to list of required Qt5 packages because Prism fails to compile without it.