### PR TITLE
fix: revert windows arm portable to msvc

### DIFF
--- a/src/download/windows.md
+++ b/src/download/windows.md
@@ -15,7 +15,7 @@ eleventyNavigation:
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MinGW-w64-Portable-{{version.current}}.zip">Portable (.zip)</a>
         <p>Windows 10/11 ARM64</p>
         <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-arm64-Setup-{{version.current}}.exe">Installer (ARM64) (.exe)</a>
-        <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MinGW-arm64-Portable-{{version.current}}.zip">Portable (ARM64) (.zip)</a>
+        <a class="button size-large" href="https://github.com/PrismLauncher/PrismLauncher/releases/download/{{version.current}}/PrismLauncher-Windows-MSVC-arm64-Portable-{{version.current}}.zip">Portable (ARM64) (.zip)</a>
       </div>
     </div>
     <div class="column">


### PR DESCRIPTION
We do not currently build mingw for arm64 so this link is broken