### PR TITLE
Update installing-java.md

### DIFF
--- a/src/wiki/getting-started/installing-java.md
+++ b/src/wiki/getting-started/installing-java.md
@@ -136,7 +136,7 @@ sudo apk add openjdk17 openjdk8
 
 ### Flatpak
 
-The Prism Launcher Flatpak already bundles Java.
+The Prism Launcher Flatpak already bundles Java. You must manually download java binaries in Settings > Java > Management tab.
 
 ### NixOS
 


### PR DESCRIPTION
fix flatpak description to tell you that java isn't manually installed and you must download binaries manually