### PR TITLE
docs: update linux qt package requirement

### DIFF
--- a/src/wiki/development/build-instructions/linux.md
+++ b/src/wiki/development/build-instructions/linux.md
@@ -28,7 +28,7 @@ Getting the project to build and run on Linux is easy if you use any modern and 
 ### Build dependencies
 
 - A C++ compiler capable of building C++17 code.
-- Qt Development tools 6.0 or newer (`qt6-base-dev qtchooser qt6-base-dev-tools libqt6core6 libqt6core5compat6-dev libqt6network6` on Debian (testing/unstable) based systems).
+- Qt Development tools 6.0 or newer (`qt6-base-dev qtchooser qt6-base-dev-tools libqt6core6 libqt6core5compat6-dev libqt6network6 qt6-networkauth-dev` on Debian (testing/unstable) based systems).
 - Alternatively, you can also use Qt 5.12 or newer (`qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5 libqt5networkauth5-dev` on Debian-based systems), if you prefer it.
 - cmake 3.15 or newer (`cmake` on Debian-based system)
 - ninja (`ninja-build` on Debian-based systems)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/91c38636-9efb-46fd-8b2c-53db7002b2a1)

fixes https://github.com/PrismLauncher/PrismLauncher/issues/2788

> Development builds now require QtNetworkAuth. as this is an un released change the documentation has not been updated . itstall the appropriate package.

at least `develop` branch requires `qt6-networkauth-dev`, so it might be a good choice to include it early.