### PR TITLE
Add DeckyCraft

### DIFF
--- a/src/wiki/getting-started/controller-support.md
+++ b/src/wiki/getting-started/controller-support.md
@@ -42,11 +42,11 @@ For Minecraft 1.16.2 to 1.18, we recommend [**LambdaControls**](https://modrinth
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
 
-### <img src="https://raw.githubusercontent.com/intergrav/Branding/main/deckcraft/mark/mark_svg.svg" height="20"> DeckCraft (for Minecraft versions 1.18.2 or newer)
+### <img src="https://cdn.modrinth.com/data/da86ZUtz/ba81f81814855e80aaf792494ef4c03e3a65cabe.png" height="20"> DeckyCraft (for Minecraft versions 1.18.2 or newer)
 
-If you're on the Steam Deck, [DeckCraft](https://modrinth.com/project/deckcraft) might be useful to you. This is a modpack designed to make it easier to play Minecraft on the Deck. It includes MidnightControls, various optimizations, features, configurations, pre-installed shaders, and more.
+If you're on the Steam Deck, [DeckyCraft](https://modrinth.com/project/deckycraft) might be useful to you. This is a Minecraft mod pack that allows you to play Minecraft on Steam Deck and other handheld PCs. In addition to mods, it also includes configurations and a proprietary resource pack, created especially for Valve's console.
 
-You can install it through the launcher by heading to `Add Instance`, select the `Modrinth` tab, then press `STEAM` + `X` together to open the keyboard and search for "DeckCraft". After this, select your preferred version and install it.
+You can install it through the launcher by heading to `Add Instance`, select the `Modrinth` tab, then press `STEAM` + `X` together to open the keyboard and search for "DeckyCraft". After this, select your preferred version and install it. For more information, visit [the project wiki](https://github.com/MStankiewiczOfficial/DeckyCraft/wiki).
 
 ## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" height="20"> Forge
 


### PR DESCRIPTION
DeckCraft is undeveloped by it's creators, so I replaced it with [DeckyCraft](https://modrinth.com/modpack/deckycraft) – my modpack for Steam Deck and other handheld PCs.