### PR TITLE
Fix translation status image overflowing layout

### DIFF
--- a/src/wiki/development/translating.md
+++ b/src/wiki/development/translating.md
@@ -10,6 +10,12 @@ eleventyNavigation:
 The translation effort for Prism Launcher is hosted on [Weblate](https://hosted.weblate.org/projects/prismlauncher/launcher/), and information about translating Prism Launcher is available at <https://github.com/PrismLauncher/Translations>
 
 Current translation progress:
-<a href="https://hosted.weblate.org/engage/prismlauncher/">
-<img src="https://hosted.weblate.org/widgets/prismlauncher/-/launcher/multi-auto.svg" alt="Translation status" align="right" />
-</a>
+<div style="display: flex; justify-content: flex-end; max-width: 100%; overflow: hidden; margin-bottom: 1rem;">
+  <a href="https://hosted.weblate.org/engage/prismlauncher/">
+    <img 
+      src="https://hosted.weblate.org/widgets/prismlauncher/-/launcher/multi-auto.svg" 
+      alt="Translation status" 
+      style="max-width: 100%; height: auto;" 
+    />
+  </a>
+</div>

--- a/src/wiki/development/translating.md
+++ b/src/wiki/development/translating.md
@@ -12,10 +12,10 @@ The translation effort for Prism Launcher is hosted on [Weblate](https://hosted.
 Current translation progress:
 <div style="display: flex; justify-content: flex-end; max-width: 100%; overflow: hidden; margin-bottom: 1rem;">
   <a href="https://hosted.weblate.org/engage/prismlauncher/">
-    <img 
-      src="https://hosted.weblate.org/widgets/prismlauncher/-/launcher/multi-auto.svg" 
-      alt="Translation status" 
-      style="max-width: 100%; height: auto;" 
+    <img
+      src="https://hosted.weblate.org/widgets/prismlauncher/-/launcher/multi-auto.svg"
+      alt="Translation status"
+      style="max-width: 100%; height: auto;"
     />
   </a>
 </div>


### PR DESCRIPTION
Fix: prevent layout overflow from Weblate translation status image

Replaced float-based layout with a flex container and responsive styles to ensure the Weblate translation status SVG scales correctly and no longer breaks the page layout.