### PR TITLE
Improve link color for contrast and visual harmony

### DIFF
--- a/src/_includes/index.css
+++ b/src/_includes/index.css
@@ -19,21 +19,21 @@
   --disabled: #666;
 
   --primary: hsl(350, 66%, 63%);
-  --link: hsl(214, 46%, 52%);
+  --link: hsl(120, 61%, 50%);
   --info: hsl(274, 32%, 42%);
   --success: hsl(145, 27%, 59%);
   --warn: hsl(49, 85%, 69%);
   --danger: hsl(17, 95%, 70%);
 
   --primary-dark: hsl(350, 66%, 55%);
-  --link-dark: hsl(214, 46%, 42%);
+  --link-dark: hsl(120, 61%, 38%);
   --info-dark: hsl(274, 32%, 32%);
   --success-dark: hsl(145, 27%, 49%);
   --warn-dark: hsl(49, 85%, 60%);
   --danger-dark: hsl(17, 95%, 65%);
 
   --primary-light: hsl(350, 66%, 70%);
-  --link-light: hsl(214, 46%, 67%);
+  --link-light: hsl(120, 61%, 65%);
   --info-light: hsl(274, 32%, 56%);
   --success-light: hsl(145, 27%, 67%);
   --warn-light: hsl(49, 85%, 79%);

--- a/src/wiki/branding/index.md
+++ b/src/wiki/branding/index.md
@@ -27,21 +27,21 @@ colors:
 --disabled: #666;
 
 --primary: hsl(350, 66%, 63%);
---link: hsl(214, 46%, 52%);
+--link: hsl(120, 61%, 50%);
 --info: hsl(274, 32%, 42%);
 --success: hsl(145, 27%, 59%);
 --warn: hsl(49, 85%, 69%);
 --danger: hsl(17, 95%, 70%);
 
 --primary-dark: hsl(350, 66%, 55%);
---link-dark: hsl(214, 46%, 42%);
+--link-dark: hsl(120, 61%, 38%);
 --info-dark: hsl(274, 32%, 32%);
 --success-dark: hsl(145, 27%, 49%);
 --warn-dark: hsl(49, 85%, 60%);
 --danger-dark: hsl(17, 95%, 65%);
 
 --primary-light: hsl(350, 66%, 70%);
---link-light: hsl(214, 46%, 67%);
+--link-light: hsl(120, 61%, 65%);
 --info-light: hsl(274, 32%, 56%);
 --success-light: hsl(145, 27%, 67%);
 --warn-light: hsl(49, 85%, 79%);


### PR DESCRIPTION
This PR updates the link color variables in the CSS to improve readability and visual accessibility, especially on dark backgrounds.

### Problem
The previous link color (`hsl(214, 46%, 52%)`, a muted blue) had insufficient contrast against dark sections of the site (e.g., black or dark grey backgrounds), making links barely visible and hard to distinguish from regular text.

### Solution
Switched to a green tone (`hsl(120, 61%, 50%)`) that offers significantly better contrast and still fits the overall design theme. Also adjusted the light and dark variants for hover/active states accordingly:
- `--link: hsl(120, 61%, 50%)`
- `--link-light: hsl(120, 61%, 65%)`
- `--link-dark: hsl(120, 61%, 38%)`

These changes improve both usability and aesthetic harmony.

### Notes
Tested on both light and dark background sections of the site. All changes are limited to CSS custom properties and do not affect functionality.

---

Let me know if any further color tuning is preferred!
