### PR TITLE
Fix link to Code of Conduct

### DIFF
--- a/src/_includes/partials/comments.njk
+++ b/src/_includes/partials/comments.njk
@@ -5,7 +5,7 @@
         </summary>
         <div>
 {% markdown %}
-By submitting a comment, you agree to uphold the [Prism Launcher Code of Conduct](prismlauncher.org/wiki/overview/code-of-conduct/).
+By submitting a comment, you agree to uphold the [Prism Launcher Code of Conduct](/wiki/overview/code-of-conduct/).
 
 ✅ What user-contributed comments are for
 


### PR DESCRIPTION
`prismlauncher.org/wiki/overview/code-of-conduct/` is a relative link which won't work well, so I did `/wiki/overview/code-of-conduct/` (absolute path) instead so it goes to the correct page, despite the domain.