### PR TITLE
feat: update download button links based on UA

### DIFF
--- a/.github/workflows/formatter-check.yaml
+++ b/.github/workflows/formatter-check.yaml
@@ -1,0 +1,14 @@
+name: Code Quality Checks
+on: [pull_request]
+
+jobs:
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install Dependencies
+        run: bun install
+      - name: Run Prettier Check
+        run: bun run format:check

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 		"dev": "astro dev",
 		"build": "astro build",
 		"preview": "astro preview",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"format:check": "prettier --check ."
 	},
 	"dependencies": {
 		"@astrojs/mdx": "^4.3.1",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import Logo from "./Logo.astro";
 import Button from "./ui/Button.astro";
+import DownloadButton from "./ui/DownloadButton.astro";
 ---
 
 <header
@@ -23,7 +24,7 @@ import Button from "./ui/Button.astro";
 	</div>
 
 	<div class="flex justify-center gap-2">
-		<Button href="/download" variant="primary" size="sm">Download</Button>
+		<DownloadButton size="sm" />
 		<Button
 			href="https://opencollective.com/prismlauncher"
 			variant="secondary"

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -1,5 +1,6 @@
 ---
 import Button from "./ui/Button.astro";
+import DownloadButton from "./ui/DownloadButton.astro";
 ---
 
 <section
@@ -13,9 +14,7 @@ import Button from "./ui/Button.astro";
 			redistributability.
 		</p>
 		<div class="not-prose">
-			<Button href="/download" variant="primary" size="lg">
-				Download Now
-			</Button>
+			<DownloadButton size="lg" />
 		</div>
 	</div>
 

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -17,6 +17,7 @@ const {
 	icon,
 	secondaryIcon,
 	class: className = "",
+	...rest
 } = Astro.props;
 
 const buttonVariants = {
@@ -47,6 +48,7 @@ const iconSize = size === "sm" ? "14" : size === "lg" ? "20" : "16";
 		"hover:brightness-110 focus:brightness-110 active:brightness-90",
 		className,
 	]}
+	{...rest}
 >
 	{icon && <Icon name={icon} size={iconSize} />}
 	<slot />

--- a/src/components/ui/DownloadButton.astro
+++ b/src/components/ui/DownloadButton.astro
@@ -1,0 +1,28 @@
+---
+import Button from "./Button.astro";
+
+interface Props {
+	size?: "sm" | "md" | "lg";
+}
+
+const { size } = Astro.props;
+---
+
+<Button
+	data-download-button
+	href="/download/windows"
+	variant="primary"
+	size={size}>Download</Button
+>
+
+<script>
+	import { determineDownloadLink } from "../../scripts/downloads";
+
+	const btns = document.querySelectorAll("[data-download-button]");
+
+	const downloadLink = determineDownloadLink();
+
+	for (const btn of btns) {
+		btn.setAttribute("href", downloadLink);
+	}
+</script>

--- a/src/components/ui/DownloadLink.astro
+++ b/src/components/ui/DownloadLink.astro
@@ -1,0 +1,17 @@
+---
+
+---
+
+<a data-download-link href="/download/windows"><slot>Download</slot></a>
+
+<script>
+	import { determineDownloadLink } from "../../scripts/downloads";
+
+	const anchors = document.querySelectorAll("[data-download-link]");
+
+	const downloadLink = determineDownloadLink();
+
+	for (const anchor of anchors) {
+		anchor.setAttribute("href", downloadLink);
+	}
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import MainLayout from "../layouts/MainLayout.astro";
 import HeroSection from "../components/HeroSection.astro";
 import ProseCard from "../components/ui/ProseCard.astro";
 import LogoCard from "../components/ui/LogoCard.astro";
+import DownloadLink from "../components/ui/DownloadLink.astro";
 ---
 
 <MainLayout
@@ -112,8 +113,8 @@ import LogoCard from "../components/ui/LogoCard.astro";
 		<h2>I want that!</h2>
 		<p>
 			You can install Prism Launcher on Windows, MacOS, and Linux. See the{" "}
-			<a href="/download">Download page</a> for more information. You can also find
-			community packages there.
+			<DownloadLink>Download page</DownloadLink> for more information. You can also
+			find community packages there.
 		</p>
 	</ProseCard>
 	<ProseCard>

--- a/src/scripts/downloads.ts
+++ b/src/scripts/downloads.ts
@@ -1,0 +1,13 @@
+export const determineDownloadLink = () => {
+	const { userAgent, platform } = navigator;
+	const ua = userAgent.toLowerCase();
+	const p = platform.toLowerCase();
+
+	if (ua.includes("windows") || p.includes("win")) {
+		return "/download/windows";
+	}
+	if (ua.includes("mac") || p.includes("mac")) {
+		return "/download/macos";
+	}
+	return "/download/linux";
+};


### PR DESCRIPTION
This feels sleeker than showing a redirect page for every download button. I have left the redirect page intact, for links from other places, like the GH releases.