### PR TITLE
Clearing up Arch Download Instructions.

### DIFF
--- a/src/download/linux.md
+++ b/src/download/linux.md
@@ -98,19 +98,19 @@ apk add prismlauncher
 
 ## <img src="https://www.vectorlogo.zone/logos/archlinux/archlinux-icon.svg" alt="Arch Linux Logo" height="20"/> Arch Linux / <img src="https://upload.wikimedia.org/wikipedia/commons/3/3e/Manjaro-logo.svg" alt="Manjaro Linux Logo" height="20"/> Manjaro
 
-Packages are available in the official Arch Linux/Manjaro repositories and the AUR (Development Builds)
+Packages are available in both the official Arch Linux/Manjaro repositories and the AUR (Development Builds)
 
 [![prismlauncher](https://img.shields.io/badge/Arch%20Linux-prismlauncher-blue?logo=archlinux&logoColor=white)](https://archlinux.org/packages/extra/x86_64/prismlauncher/)
 [![prismlauncher-git](https://img.shields.io/badge/AUR-prismlauncher--git-blue?logo=archlinux&logoColor=white)](https://aur.archlinux.org/packages/prismlauncher-git/)
 
-### Installing
+### Installing Prism
 
 ```bash
 # Latest release (binary)
 sudo pacman -S prismlauncher
 ```
 
-### Installing Dev Build (AUR)
+### Installing Dev Builds (AUR)
 
 ```bash
 # Newest Git commit (compiled from source)


### PR DESCRIPTION
Tiding us over until @ZekeZDev finishes up the website redesign. (new download page)
Current instructions are a bit indirect.
Removes Chaotic AUR
Leaves git packaging but differentiates it.