### PR TITLE
use 1em height for custom inline icons

### DIFF
--- a/src/content/docs/wiki/getting-started/controller-support.md
+++ b/src/content/docs/wiki/getting-started/controller-support.md
@@ -18,23 +18,23 @@ Finally, if you don't have one already, you must create an **instance** with the
 
 This includes Steam Deck's Gamepad, PlayStation/Xbox controllers and so on.
 
-## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" width=30px style="display: inline-block"><img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" width=30px style="display: inline-block"> Fabric/Quilt
+## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" style="height: 1em; display: inline"><img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" style="height: 1em; display: inline"> Fabric/Quilt
 
 Before you continue, ensure that the correct version of the **Fabric API** mod on **Fabric** or the **Quilted Fabric API** mod on **Quilt** for your instance is installed.
 
-### <img src="https://cdn.modrinth.com/data/DOUdJVEm/4f8cdb3933f9efa0c5dfd5574d3ad6b101c7f3ef.png" alt="Controlify Fabric" width=20px style="display: inline-block"> Controlify (for Minecraft Versions 1.19.4 or newer)
+### <img src="https://cdn.modrinth.com/data/DOUdJVEm/4f8cdb3933f9efa0c5dfd5574d3ad6b101c7f3ef.png" alt="Controlify Fabric" style="height: 1em; display: inline"> Controlify (for Minecraft Versions 1.19.4 or newer)
 
 For Minecraft 1.19.4 or newer, we recommend [**Controlify**](https://modrinth.com/mod/controlify). It's a controller mod that has [a lot of features that aren't in MidnightControls](https://moddedmc.wiki/en/project/controlify/latest/docs/users/mod-comparison).
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controller menu (Options -> Controls -> Controller Settings) and do the calibration. Once that's done, you're ready to use your controller!
 
-### <img src="https://cdn-raw.modrinth.com/data/bXX9h73M/icon.svg" alt="MidnightControls Fabric" width=20px style="display: inline-block"> MidnightControls (for Minecraft Versions 1.18 or newer)
+### <img src="https://cdn-raw.modrinth.com/data/bXX9h73M/icon.svg" alt="MidnightControls Fabric" style="height: 1em; display: inline"> MidnightControls (for Minecraft Versions 1.18 or newer)
 
 For Minecraft 1.18 or newer, we recommend [**MidnightControls**](https://modrinth.com/mod/midnightcontrols), an updated fork of LambdaControls.
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
 
-### <img src="https://cdn-raw.modrinth.com/data/W1D3UXEc/icon.png" alt="LambdaControls Logo" width=20px style="display: inline-block"> LambdaControls (for Minecraft Versions 1.16.2 to 1.18)
+### <img src="https://cdn-raw.modrinth.com/data/W1D3UXEc/icon.png" alt="LambdaControls Logo" style="height: 1em; display: inline"> LambdaControls (for Minecraft Versions 1.16.2 to 1.18)
 
 **NOTE:** This mod is currently unmaintained and hasn't been updated since June of 2021, so unless you really need to, use MidnightControls.
 
@@ -42,29 +42,29 @@ For Minecraft 1.16.2 to 1.18, we recommend [**LambdaControls**](https://modrinth
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
 
-## <img src="https://raw.githubusercontent.com/neoforged/websites/66732fa21e1a0d7b73df5c2f18a5345bbe13871f/assets/img/content/branding/icon.png" alt="NeoForge Logo" width=30px style="display: inline-block"> NeoForge
+## <img src="https://raw.githubusercontent.com/neoforged/websites/66732fa21e1a0d7b73df5c2f18a5345bbe13871f/assets/img/content/branding/icon.png" alt="NeoForge Logo" style="height: 1em; display: inline"> NeoForge
 
-### <img src="https://cdn.modrinth.com/data/DOUdJVEm/4f8cdb3933f9efa0c5dfd5574d3ad6b101c7f3ef.png" alt="Controlify NeoForge" width=20px style="display: inline-block"> Controlify (for Minecraft Versions 1.20.3 or newer)
+### <img src="https://cdn.modrinth.com/data/DOUdJVEm/4f8cdb3933f9efa0c5dfd5574d3ad6b101c7f3ef.png" alt="Controlify NeoForge" style="height: 1em; display: inline"> Controlify (for Minecraft Versions 1.20.3 or newer)
 
 For Minecraft 1.20.3 or newer, we recommend [**Controlify**](https://modrinth.com/mod/controlify). It's a controller mod that has [a lot of features that aren't in MidnightControls or Controllable](https://moddedmc.wiki/en/project/controlify/latest/docs/users/mod-comparison).
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controller menu (Options -> Controls -> Controller Settings) and do the calibration. Once that's done, you're ready to use your controller!
 
-### <img src="https://cdn-raw.modrinth.com/data/bXX9h73M/icon.svg" alt="MidnightControls NeoForge" width=20px style="display: inline-block"> MidnightControls (for Minecraft Versions 1.21 or newer)
+### <img src="https://cdn-raw.modrinth.com/data/bXX9h73M/icon.svg" alt="MidnightControls NeoForge" style="height: 1em; display: inline"> MidnightControls (for Minecraft Versions 1.21 or newer)
 
 For Minecraft 1.21 or newer, we recommend [**MidnightControls**](https://modrinth.com/mod/midnightcontrols), an updated fork of LambdaControls.
 
 It can be installed using Prism Launcher's mod downloader function through either Modrinth (recommended) or CurseForge. Once installed, please launch your instance and navigate to the in-game controls menu. Within the in-game controls menu, you may need to change the "Mode" setting to **Controller** in order for the game to respond to input from the gamepad. If it doesn't work, you can use [**the app linked in the mod**](https://generalarcade.com/gamepadtool/) to edit the controller mappings.
 
-### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" alt="Controllable NeoForge" width=20px style="display: inline-block"> Controllable (for Minecraft Versions 1.20.4 or newer)
+### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" alt="Controllable NeoForge" style="height: 1em; display: inline"> Controllable (for Minecraft Versions 1.20.4 or newer)
 
 For Minecraft versions 1.20.4 or above, we also recommend [**Controllable**](https://www.curseforge.com/minecraft/mc-mods/controllable).
 
 Controllable can be installed using Prism Launcher's mod downloader function through CurseForge. Once installed, you may now launch your instance, and find that the mod should begin working immediately.
 
-## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" width=30px style="display: inline-block"> Forge
+## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" style="height: 1em; display: inline"> Forge
 
-### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" alt="Controllable Forge" width=20px style="display: inline-block"> Controllable (for Minecraft Versions 1.12.2 or newer)
+### <img src="https://raw.githubusercontent.com/MrCrayfish/Controllable/6caef1a4ac113e5c6ac1d1abde0f0cabc3e6ad97/src/main/resources/controllable_icon.png" alt="Controllable Forge" style="height: 1em; display: inline"> Controllable (for Minecraft Versions 1.12.2 or newer)
 
 For Minecraft versions 1.12.2 or above, we also recommend [**Controllable**](https://www.curseforge.com/minecraft/mc-mods/controllable).
 

--- a/src/content/docs/wiki/getting-started/download-mods.md
+++ b/src/content/docs/wiki/getting-started/download-mods.md
@@ -14,12 +14,12 @@ It is worth noting that many mods will be available on **both platforms**.
 
 After you've chosen your mod provider, you can search or browse for any desired mods. Click the **Select mod for download** button to add each mod to your download queue. Once finished, you can now press **OK**, and your mods should begin downloading.
 
-## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" width=30px style="display: inline-block"> Fabric
+## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" style="height: 1em; display: inline"> Fabric
 
 If you have selected to use the **Fabric** mod loader, then please ensure that the latest version of the **Fabric API** mod available for your game version is installed. It is mostly **required** for Fabric mods.
 
 If it is missing, you can install it from **Edit** > **Mods** > **Download mods** like any other mod.
 
-## <img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" width=30px style="display: inline-block"> Quilt
+## <img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" style="height: 1em; display: inline"> Quilt
 
 For installing Quilt in Prism Launcher, follow the [quilt wiki](https://quiltmc.org/install/prismlauncher/).

--- a/src/content/docs/wiki/getting-started/install-of-alternatives.md
+++ b/src/content/docs/wiki/getting-started/install-of-alternatives.md
@@ -24,79 +24,79 @@ In the past few years, various mods have been made to replace these features and
 
 To install mods and modpacks, see the [Download mods](../download-mods) and [Download modpacks](../download-modpacks) pages.
 
-## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" width=30px style="display: inline-block"><img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" width=30px style="display: inline-block"> Fabric/Quilt Mods
+## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" style="height: 1em; display: inline"><img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" style="height: 1em; display: inline"> Fabric/Quilt Mods
 
 <div class="notification type-info">
 Most Fabric mods require the <a href="https://modrinth.com/mod/fabric-api">Fabric API</a> mod in order to work, while most Quilt mods require <a href="https://modrinth.com/mod/qsl">Quilted Fabric API</a> to work.
 </div>
 
-### <img src="https://cdn.modrinth.com/data/AANobbMI/icon.png" alt="Sodium Logo" width=20px style="display: inline-block"> Sodium
+### <img src="https://cdn.modrinth.com/data/AANobbMI/icon.png" alt="Sodium Logo" style="height: 1em; display: inline"> Sodium
 
 [Sodium](https://modrinth.com/mod/sodium) is a mod that greatly improves render performance through various rendering optimizations. We **highly recommend** installing it when possible.
 
 If you use Sodium often, please consider supporting development of the mod by [donating](https://jellysquid.me/donate) to the developer!
 
-### <img src="https://cdn.modrinth.com/data/gvQqBUqZ/icon.png" alt="Lithium Logo" width=20px style="display: inline-block"> Lithium
+### <img src="https://cdn.modrinth.com/data/gvQqBUqZ/icon.png" alt="Lithium Logo" style="height: 1em; display: inline"> Lithium
 
 [Lithium](https://modrinth.com/mod/lithium) is a mod that greatly improves render performance through various game logic optimizations. We **highly recommend** installing it when possible.
 
-### <img src="https://raw.githubusercontent.com/IrisShaders/Iris/trunk/src/main/resources/assets/iris/iris-logo.png" alt="Iris Logo" width=20px style="display: inline-block"> Iris
+### <img src="https://raw.githubusercontent.com/IrisShaders/Iris/trunk/src/main/resources/assets/iris/iris-logo.png" alt="Iris Logo" style="height: 1em; display: inline"> Iris
 
 [Iris](https://irisshaders.dev/) allows you to use OptiFine shaderpacks, while also running Sodium. It currently supports almost every shaderpack, [with some exceptions](https://github.com/IrisShaders/Iris/blob/1.21.9/docs/unsupportedshaders.md).
 
-### <img src="https://cdn.modrinth.com/data/5ZwdcRci/e57b6b451425692ac17ad322d5e14bea686a383a_96.webp" alt="ImmediatelyFast Fabric" width=20px style="display: inline-block"> ImmediatelyFast
+### <img src="https://cdn.modrinth.com/data/5ZwdcRci/e57b6b451425692ac17ad322d5e14bea686a383a_96.webp" alt="ImmediatelyFast Fabric" style="height: 1em; display: inline"> ImmediatelyFast
 
 [ImmediatelyFast](https://modrinth.com/mod/immediatelyfast) is an open source Minecraft mod which improves the immediate mode rendering performance of the client. We **highly recommend** installing it when possible.
 
-### <img src="https://cdn.modrinth.com/data/Orvt0mRa/icon.png" alt="Indium Logo" width=20px style="display: inline-block"> Indium
+### <img src="https://cdn.modrinth.com/data/Orvt0mRa/icon.png" alt="Indium Logo" style="height: 1em; display: inline"> Indium
 
 [Indium](https://modrinth.com/mod/indium) is an addon for older Sodium versions that provides support for the Fabric Rendering API. This is needed if you want to use Sodium on Minecraft 1.20.x or older with mods that use advanced rendering techniques.
 
-### <img src="https://cdn.modrinth.com/data/gvQqBUqZ/icon.png" alt="Lithium Logo" width=20px style="display: inline-block"><img src="https://cdn.modrinth.com/data/H8CaAYZC/icon.png" alt="Starlight Logo" width=20px style="display: inline-block"> Other Mods
+### <img src="https://cdn.modrinth.com/data/gvQqBUqZ/icon.png" alt="Lithium Logo" style="height: 1em; display: inline"><img src="https://cdn.modrinth.com/data/H8CaAYZC/icon.png" alt="Starlight Logo" style="height: 1em; display: inline"> Other Mods
 
 If you would like to go a bit further, LambdAurora maintains a [very detailed list of OptiFine alternatives for Fabric and Quilt](https://lambdaurora.dev/optifine_alternatives/). There's also [a list of mods used by the Additive modpack](https://github.com/skywardmc/additive/wiki/Give-up-OptiFine), which provides the Minecraft versions that each mod supports along with some extra information.
 
-## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" width=30px style="display: inline-block"><img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" width=30px style="display: inline-block"> Fabric/Quilt Modpacks
+## <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" style="height: 1em; display: inline"><img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" style="height: 1em; display: inline"> Fabric/Quilt Modpacks
 
-### <img src="https://raw.githubusercontent.com/skywardmc/art/main/additive/logo_512h.png" alt="Additive Logo" width=20px style="display: inline-block"> Additive
+### <img src="https://raw.githubusercontent.com/skywardmc/art/main/additive/logo_512h.png" alt="Additive Logo" style="height: 1em; display: inline"> Additive
 
 [Additive](https://modrinth.com/modpack/additive) is a modpack similar to Fabulously Optimized which aims to support nearly all OptiFine features. It's based on Adrenaline for better performance, supports Fabric, and can be installed on a wide range of Minecraft versions.
 
-### <img src="https://raw.githubusercontent.com/skywardmc/art/main/adrenaline/logo_512h.png" alt="Adrenaline Logo" width=20px style="display: inline-block"> Adrenaline
+### <img src="https://raw.githubusercontent.com/skywardmc/art/main/adrenaline/logo_512h.png" alt="Adrenaline Logo" style="height: 1em; display: inline"> Adrenaline
 
 [Adrenaline](https://modrinth.com/modpack/adrenaline) is a Fabric modpack which aims to improve performance as much as possible while not changing anything about the vanilla game and not introducing instability. Like Simply Optimized, it does not come with any OptiFine replacement mods, so you'll have to manually install the features that you want.
 
-### <img src="https://avatars.githubusercontent.com/u/92206402?s=200&v=4" alt="Fabulously Optimized Logo" width=20px style="display: inline-block"> Fabulously Optimized
+### <img src="https://avatars.githubusercontent.com/u/92206402?s=200&v=4" alt="Fabulously Optimized Logo" style="height: 1em; display: inline"> Fabulously Optimized
 
 If you don't want to search and install these mods manually, then try the [Fabulously Optimized](https://modrinth.com/modpack/fabulously-optimized) modpack, which supports almost all OptiFine features.
 
 [See the installation instructions](https://fabulously-optimized.gitbook.io/modpack/readme/install-instructions#prism-launcher) for Prism Launcher.
 
-### <img src="https://cdn.modrinth.com/data/BYfVnHa7/icon.png" alt="Simply Optimized Logo" width=20px style="display: inline-block"> Simply Optimized
+### <img src="https://cdn.modrinth.com/data/BYfVnHa7/icon.png" alt="Simply Optimized Logo" style="height: 1em; display: inline"> Simply Optimized
 
 [Simply Optimized](https://modrinth.com/modpack/sop) is a modpack designed with just optimization in mind. SO has better out-of-the-box performance than Fabulously Optimized, but it doesn't come with the QoL mods or full OptiFine parity you would see in Fabulously Optimized, so you're expected to add any additional mods you want yourself.
 
-## <img src="https://raw.githubusercontent.com/neoforged/websites/66732fa21e1a0d7b73df5c2f18a5345bbe13871f/assets/img/content/branding/icon.png" alt="NeoForge Logo" width=30px style="display: inline-block"> NeoForge Mods
+## <img src="https://raw.githubusercontent.com/neoforged/websites/66732fa21e1a0d7b73df5c2f18a5345bbe13871f/assets/img/content/branding/icon.png" alt="NeoForge Logo" style="height: 1em; display: inline"> NeoForge Mods
 
-### <img src="https://cdn.modrinth.com/data/AANobbMI/icon.png" alt="Sodium Logo" width=20px style="display: inline-block"> Sodium for NeoForge
+### <img src="https://cdn.modrinth.com/data/AANobbMI/icon.png" alt="Sodium Logo" style="height: 1em; display: inline"> Sodium for NeoForge
 
 [Sodium](https://modrinth.com/mod/sodium) also exists for some Minecraft versions on NeoForge — see [its support policy](https://github.com/CaffeineMC/sodium/wiki/Support-Policy). We highly recommend installing it when possible.
 
-### <img src="https://cdn.modrinth.com/data/gvQqBUqZ/icon.png" alt="Lithium Logo" width=20px style="display: inline-block"> Lithium for NeoForge
+### <img src="https://cdn.modrinth.com/data/gvQqBUqZ/icon.png" alt="Lithium Logo" style="height: 1em; display: inline"> Lithium for NeoForge
 
 [Lithium](https://modrinth.com/mod/lithium) also exists for some Minecraft versions on NeoForge — see [its support policy](https://github.com/CaffeineMC/lithium/wiki/Support-Policy). We highly recommend installing it when possible.
 
-### <img src="https://raw.githubusercontent.com/IrisShaders/Iris/trunk/src/main/resources/assets/iris/iris-logo.png" alt="Iris Logo" width=20px style="display: inline-block"> Iris for NeoForge
+### <img src="https://raw.githubusercontent.com/IrisShaders/Iris/trunk/src/main/resources/assets/iris/iris-logo.png" alt="Iris Logo" style="height: 1em; display: inline"> Iris for NeoForge
 
 [Iris](https://irisshaders.dev/) also generally exists for the same loaders/versions as Sodium.
 
-### <img src="https://cdn.modrinth.com/data/5ZwdcRci/e57b6b451425692ac17ad322d5e14bea686a383a_96.webp" alt="ImmediatelyFast NeoForge" width=20px style="display: inline-block"> ImmediatelyFast
+### <img src="https://cdn.modrinth.com/data/5ZwdcRci/e57b6b451425692ac17ad322d5e14bea686a383a_96.webp" alt="ImmediatelyFast NeoForge" style="height: 1em; display: inline"> ImmediatelyFast
 
 [ImmediatelyFast](https://modrinth.com/mod/immediatelyfast) is an open source Minecraft mod which improves the immediate mode rendering performance of the client. We **highly recommend** installing it when possible.
 
-## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" width=30px style="display: inline-block"> Forge Mods
+## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" style="height: 1em; display: inline"> Forge Mods
 
-### <img src="https://cdn.modrinth.com/data/5ZwdcRci/e57b6b451425692ac17ad322d5e14bea686a383a_96.webp" alt="ImmediatelyFast Forge" width=20px style="display: inline-block"> ImmediatelyFast
+### <img src="https://cdn.modrinth.com/data/5ZwdcRci/e57b6b451425692ac17ad322d5e14bea686a383a_96.webp" alt="ImmediatelyFast Forge" style="height: 1em; display: inline"> ImmediatelyFast
 
 [ImmediatelyFast](https://modrinth.com/mod/immediatelyfast) is an open source Minecraft mod which improves the immediate mode rendering performance of the client. We **highly recommend** installing it when possible.
 
@@ -110,15 +110,15 @@ You can use [Sinytra Connector](https://modrinth.com/mod/connector) to run many 
 **Don't report issues with those on upstream's Discord support channels!**
 :::
 
-### <img src="https://raw.githubusercontent.com/FiniteReality/embeddium/aa6657df4eaea8bdfa6243233c893207f5b7f8b4/src/main/resources/icon.png" alt="Embeddium" width=20px style="display: inline-block"> Embeddium
+### <img src="https://raw.githubusercontent.com/FiniteReality/embeddium/aa6657df4eaea8bdfa6243233c893207f5b7f8b4/src/main/resources/icon.png" alt="Embeddium" style="height: 1em; display: inline"> Embeddium
 
 [Embeddium](https://modrinth.com/mod/embeddium) is a Sodium port for Forge that focuses on compatibility with other Forge mods. We recommend using it instead of Rubidium. Be aware of the statements above before using it.
 
-### <img src="https://raw.githubusercontent.com/Asek3/Oculus/f59f6932eb20e00d123b36d5976d6ecd80b98b41/src/main/resources/oculus-logo.png" alt="Oculus Logo" width=20px style="display: inline-block"> Oculus
+### <img src="https://raw.githubusercontent.com/Asek3/Oculus/f59f6932eb20e00d123b36d5976d6ecd80b98b41/src/main/resources/oculus-logo.png" alt="Oculus Logo" style="height: 1em; display: inline"> Oculus
 
 [Oculus](https://modrinth.com/mod/oculus) is an Iris port for Forge. Be aware of the statements above before using it.
 
-### <img src="https://raw.githubusercontent.com/Reforged-Hub/radium-upstream/40739dc656c8bd2d580b5b15d8de89593c3e9c05/src/main/resources/icon.png" alt="Radium Logo" width=20px style="display: inline-block"> Radium
+### <img src="https://raw.githubusercontent.com/Reforged-Hub/radium-upstream/40739dc656c8bd2d580b5b15d8de89593c3e9c05/src/main/resources/icon.png" alt="Radium Logo" style="height: 1em; display: inline"> Radium
 
 [Radium](https://modrinth.com/mod/radium) is a Lithium port for Forge. Be aware of the statements above before using it.
 
@@ -126,12 +126,12 @@ You can use [Sinytra Connector](https://modrinth.com/mod/connector) to run many 
 
 You can find [a list of performance mods for Forge here](https://github.com/NordicGamerFE/usefulmods#performance-and-bug-fixing-mods).
 
-## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" width=30px style="display: inline-block"> Forge Modpacks
+## <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" style="height: 1em; display: inline"> Forge Modpacks
 
-### <img src="https://raw.githubusercontent.com/skywardmc/art/main/hammer/logo_512h.png" alt="Hammer Logo" width=20px style="display: inline-block"> Hammer
+### <img src="https://raw.githubusercontent.com/skywardmc/art/main/hammer/logo_512h.png" alt="Hammer Logo" style="height: 1em; display: inline"> Hammer
 
 [Hammer](https://modrinth.com/modpack/hammer) is like the Adrenaline modpack but made for Forge, utilizing Forge ports of mods and [Sinytra Connector](https://modrinth.com/mod/connector) to run Fabric/Quilt optimization mods.
 
-### <img src="https://raw.githubusercontent.com/skywardmc/art/main/drill/logo_512h.png" alt="Drill Logo" width=20px style="display: inline-block"> Drill
+### <img src="https://raw.githubusercontent.com/skywardmc/art/main/drill/logo_512h.png" alt="Drill Logo" style="height: 1em; display: inline"> Drill
 
 [Drill](https://modrinth.com/modpack/drill) is the Additive modpack but made for Forge, utilizing Forge ports of mods and [Sinytra Connector](https://modrinth.com/mod/connector) to run Fabric/Quilt optimization and OptiFine replacement mods.

--- a/src/content/docs/wiki/getting-started/installing-optifine.md
+++ b/src/content/docs/wiki/getting-started/installing-optifine.md
@@ -12,7 +12,7 @@ Also, if you're using the Fabric mod loader, there's no native support for it, a
 Therefore, you should consider the use of OptiFine alternatives whenever possible. [See the wiki page about it](../install-of-alternatives).
 :::
 
-## <img src="https://www.optifine.net/favicon.ico" alt="OptiFine Logo" width=30px style="display: inline-block"> Installing OptiFine standalone
+## <img src="https://www.optifine.net/favicon.ico" alt="OptiFine Logo" style="height: 1em; display: inline"> Installing OptiFine standalone
 
 This method requires you either have the Minecraft version you wish to install OptiFine on to be installed through the vanilla launcher or to recreate the folder structure somewhere on your system (like /.minecraft/versions/_1.18.2_/_1.18.2_.jar).
 
@@ -33,7 +33,7 @@ From OptiFine Version **H1_pre2** the instructions for installing OptiFine on Pr
 3. Move all files from the folder called **notch** to the top folder of the archive file and click **save**.
 4. Open Prism Launcher, edit the instance you wish to install OptiFine on, open the **Version** tab and click **Add to Minecraft.jar**, select the extracted / modified OptiFine jarmod (the file ending in \_MOD.jar) and confirm.
 
-## <img src="https://www.optifine.net/favicon.ico" alt="OptiFine Logo" width=30px style="display: inline-block"> Installing OptiFine on top of a modloader
+## <img src="https://www.optifine.net/favicon.ico" alt="OptiFine Logo" style="height: 1em; display: inline"> Installing OptiFine on top of a modloader
 
 Make sure you know how to [download mods](../download-mods) before attempting to install OptiFine.
 
@@ -43,13 +43,13 @@ Once found, click **mirror**. Now click the **download** button to download your
 
 Remember where you have kept your **.jar** file, and continue to Prism Launcher. Follow the steps from the [download mods](../download-mods) page, and choose either Forge or Fabric.
 
-### <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" width=20px style="display: inline-block"> Forge
+### <img src="https://avatars0.githubusercontent.com/u/1390178?s=400&v=4" alt="Forge Logo" style="height: 1em; display: inline"> Forge
 
 Forge does not require any extra steps besides adding the **.jar** for OptiFine into Prism Launcher.
 
 **NOTE:** Some versions of OptiFine **don't** work on Forge!
 
-### <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" width=20px style="display: inline-block"> Fabric
+### <img src="https://raw.githubusercontent.com/FabricMC/community/main/media/unascribed/png/fabric.png" alt="FabricMC Logo" style="height: 1em; display: inline"> Fabric
 
 **Note:** If you're playing on Minecraft versions older than 1.16, you might need to also install the [Fabric API](../download-mods/#fabric) mod.
 
@@ -59,7 +59,7 @@ Go into the **Mods** tab on the left side and then in the right menu select **Do
 
 If there were results shown in the search, your Minecraft version may not be compatible with OptiFabric. In this case, you can either try the Forge method, or choose to wait until support for your Minecraft version is added.
 
-### <img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" width=20px style="display: inline-block"> Quilt
+### <img src="https://raw.githubusercontent.com/QuiltMC/art/master/brand/svg/quilt_logo_dark.svg" alt="QuiltMC Logo" style="height: 1em; display: inline"> Quilt
 
 There's no way of running OptiFine on Quilt at the time of writing.
 

--- a/src/content/docs/wiki/getting-started/migrating-multimc.md
+++ b/src/content/docs/wiki/getting-started/migrating-multimc.md
@@ -4,7 +4,7 @@ sidebar:
   order: 3
 ---
 
-## <img src="https://avatars2.githubusercontent.com/u/5411890" alt="MultiMC Logo" width=30px style="display: inline-block"/> In MultiMC
+## <img src="https://avatars2.githubusercontent.com/u/5411890" alt="MultiMC Logo" style="height: 1em; display: inline"/> In MultiMC
 
 In order to transfer an instance, or multiple instances from MultiMC to Prism Launcher, you must begin the process by opening MultiMC on your computer.
 
@@ -14,7 +14,7 @@ Left-click on the tab and select the **View Instance Folder** option. This shoul
 
 Now that the MultiMC instance directory is open, you may **select**, and then **copy** the instances that you wish to transfer.
 
-## <img src="https://raw.githubusercontent.com/PrismLauncher/PrismLauncher/develop/program_info/org.prismlauncher.PrismLauncher.svg" alt="Prism Launcher Logo" width=30px style="display: inline-block"> In Prism Launcher
+## <img src="https://raw.githubusercontent.com/PrismLauncher/PrismLauncher/develop/program_info/org.prismlauncher.PrismLauncher.svg" alt="Prism Launcher Logo" style="height: 1em; display: inline"> In Prism Launcher
 
 To complete the transfer process, you must now open Prism Launcher.
 

--- a/src/content/docs/wiki/overview/troubleshooting.md
+++ b/src/content/docs/wiki/overview/troubleshooting.md
@@ -27,7 +27,7 @@ A workaround for this issue is adding the following JVM argument:
 
 ## Common Launcher-related issues
 
-### <img src="https://upload.wikimedia.org/wikipedia/commons/8/87/Windows_logo_-_2021.svg" alt="Windows Logo" width=20px style="display: inline-block" /> Windows (7, 8.1, 10, 11)
+### <img src="https://upload.wikimedia.org/wikipedia/commons/8/87/Windows_logo_-_2021.svg" alt="Windows Logo" style="height: 1em; display: inline" /> Windows (7, 8.1, 10, 11)
 
 #### "MSVCP140_2.dll was not found"?
 
@@ -48,14 +48,14 @@ This is unfortunately **normal behaviour** due to the nature of the Windows app 
 
 If you are **comfortable** and **trust** Prism Launcher, then you can click on the **More info** button, and then do the same on the **Run anyway** one too.
 
-### <img src="https://upload.wikimedia.org/wikipedia/de/c/c2/Microsoft_Windows_7_logo.svg" alt="Windows 7 Logo" width=20px style="display: inline-block" /> Windows 7 and 8.1
+### <img src="https://upload.wikimedia.org/wikipedia/de/c/c2/Microsoft_Windows_7_logo.svg" alt="Windows 7 Logo" style="height: 1em; display: inline" /> Windows 7 and 8.1
 
 #### "api-ms-win-core-synch-l1-2.0.dll not found" or "The procedure entry point CreateDXGIFactory2 could not be located in the dynamic link library dxgi.dll"?
 
 Prism Launcher hasn't supported Windows 7 and Windows 8.1 since version 8.0 due to dependencies. These operating systems have been EOL for years, so please upgrade your operating system for security reasons.
 [Prism Launcher 7.2](https://github.com/PrismLauncher/PrismLauncher/releases/tag/7.2) is the last version that has a legacy build for these EOL operating systems, but it's no longer supported.
 
-### <img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/TuxFlat.svg" alt="Linux Tux Logo" width=20px style="display: inline-block" /> Linux
+### <img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/TuxFlat.svg" alt="Linux Tux Logo" style="height: 1em; display: inline" /> Linux
 
 #### How do I install the Prism Launcher Flatpak on my Linux system?
 
@@ -82,7 +82,7 @@ This means that some themes and theming platforms like KDE Plasma's theming will
 But don't worry, we still provide Qt 5 builds.
 You can find them on the [download page](https://prismlauncher.org/download/linux).
 
-### <img src="https://upload.wikimedia.org/wikipedia/commons/8/87/Windows_logo_-_2021.svg" alt="Windows Logo" width=20px style="display: inline-block" /> <img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/TuxFlat.svg" alt="Linux Tux Logo" width=20px style="display: inline-block" /> Windows and Linux
+### <img src="https://upload.wikimedia.org/wikipedia/commons/8/87/Windows_logo_-_2021.svg" alt="Windows Logo" style="height: 1em; display: inline" /> <img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/TuxFlat.svg" alt="Linux Tux Logo" style="height: 1em; display: inline" /> Windows and Linux
 
 #### I want to make my system install portable
 


### PR DESCRIPTION
changed it to em since thats relative to font size, instead of px sizes.

### original description:
dunno how to apply global css classes here (tried global.css), please suggest a way to not repeat the height and display property for every inline image.

also I search and replaced any `height="20"` with this, so if something used a different height or set the width instead I would've missed that.

