### PR TITLE
feat: set width on images in download page

### DIFF
--- a/src/layouts/DownloadLayout.astro
+++ b/src/layouts/DownloadLayout.astro
@@ -80,6 +80,7 @@ const images = {
 						<Picture
 							src={images.light}
 							formats={["avif", "webp"]}
+							width="600"
 							alt={screenshotAlt || `Prism Launcher screenshot on ${platform}`}
 							class="mx-auto not-prose"
 							pictureAttributes={{
@@ -89,6 +90,7 @@ const images = {
 						<Picture
 							src={images.dark}
 							formats={["avif", "webp"]}
+							width="600"
 							alt={screenshotAlt || `Prism Launcher screenshot on ${platform}`}
 							class="mx-auto not-prose"
 							pictureAttributes={{


### PR DESCRIPTION
the image on the macOS page is massive so this fixes that