### PR TITLE
add MacPorts install instructions

### DIFF
--- a/src/pages/download/macos.md
+++ b/src/pages/download/macos.md
@@ -26,6 +26,14 @@ You can also install Prism Launcher via Homebrew:
 brew install --cask prismlauncher
 ```
 
+### MacPorts
+
+Install through MacPorts is also available:
+
+```bash
+sudo port install PrismLauncher
+```
+
 ### Nix
 
 See the [Linux section](/download/linux) for Nix information.


### PR DESCRIPTION
This was in the old website, so I'm curious as to why it wasn't ported over.