### PR TITLE
fix: add one header level for arch devel package because the official…

### DIFF
--- a/src/pages/download/linux.md
+++ b/src/pages/download/linux.md
@@ -86,7 +86,7 @@ Packages are available in both the official Arch Linux/Manjaro repositories and 
 sudo pacman -S prismlauncher
 ```
 
-### Installing Dev Builds (AUR)
+#### Installing Dev Builds (AUR)
 
 ```bash
 # Newest Git commit (compiled from source)


### PR DESCRIPTION
… package has it