### PR TITLE
Fix build instructions for macOS, remove vulkan-headers

### DIFF
--- a/src/content/docs/wiki/development/build-instructions.mdx
+++ b/src/content/docs/wiki/development/build-instructions.mdx
@@ -203,8 +203,8 @@ cmake --preset windows_mingw
 
 ```bash
 cmake --preset macos \
-  -D CMAKE_PREFIX_PATH="/opt/homebrew/opt/qt"
-  -D CMAKE_OSX_DEPLOYMENT_TARGET=12 \
+  -D CMAKE_PREFIX_PATH="/opt/homebrew/opt/qt" \
+  -D CMAKE_OSX_DEPLOYMENT_TARGET=12
 ```
 
 </TabItem>

--- a/src/content/docs/wiki/development/build-instructions.mdx
+++ b/src/content/docs/wiki/development/build-instructions.mdx
@@ -121,7 +121,7 @@ xcode-select --install
 Qt and other dependencies can then be installed with the following [Homebrew](https://brew.sh/) command:
 
 ```console
-brew install cmake ninja extra-cmake-modules openjdk@17 vcpkg qt
+brew install cmake pkg-config ninja extra-cmake-modules openjdk@17 vcpkg qt
 git clone https://github.com/Microsoft/vcpkg ~/vcpkg
 export VCPKG_ROOT="$HOME/vcpkg"
 ```

--- a/src/content/docs/wiki/development/build-instructions.mdx
+++ b/src/content/docs/wiki/development/build-instructions.mdx
@@ -25,14 +25,12 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   - Qt Svg
 - cmark
 - gamemode (required at build time, optional at runtime. Only on Linux)
-- `glxinfo` (required at runtime, only on Linux)
 - libarchive
 - libGL headers (only on Linux)
 - libqrencode
 - pciutils (required at runtime, only on Linux)
 - scdoc (optional at build time, used to generate manpages)
 - tomlplusplus
-- vulkan-headers
 - zlib
 
 <Tabs syncKey="buildInstructions">
@@ -105,7 +103,6 @@ pacboy -S \
 	libarchive:p \
 	qrencode:p \
 	tomlplusplus:p \
-	vulkan-headers:p \
 	zlib:p
 ```
 
@@ -160,7 +157,7 @@ sudo pacman -S \
   base-devel \
   cmake ninja extra-cmake-modules pkg-config scdoc \
   qt6-base qt6-imageformats qt6-networkauth qt6-svg \
-  cmark gamemode libarchive mesa qrencode tomlplusplus vulkan-headers zlib \
+  cmark gamemode libarchive mesa qrencode tomlplusplus zlib \
   jdk17-openjdk
 ```
 


### PR DESCRIPTION
the "command continuation" symbol (idk what its called) is placed on the wrong line

Closes #1214 