### PR TITLE
fix: typo in mac build instructions

### DIFF
--- a/src/content/docs/wiki/development/build-instructions.mdx
+++ b/src/content/docs/wiki/development/build-instructions.mdx
@@ -203,8 +203,8 @@ cmake --preset windows_mingw
 
 ```bash
 cmake --preset macos \
-  -D CMAKE_PREFIX_PATH="/opt/homebrew/opt/qt"
-  -D CMAKE_OSX_DEPLOYMENT_TARGET=12 \
+  -D CMAKE_PREFIX_PATH="/opt/homebrew/opt/qt" \
+  -D CMAKE_OSX_DEPLOYMENT_TARGET=12
 ```
 
 </TabItem>


### PR DESCRIPTION
The backslash is on the wrong line.