### PR TITLE
feat(wiki): add theme screenshots

### DIFF
--- a/src/content/docs/wiki/getting-started/change-themes.md
+++ b/src/content/docs/wiki/getting-started/change-themes.md
@@ -118,19 +118,19 @@ Themes can help you spice up your launcher appearance.
   <summary aria-label="Show screenshots">
     <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Dark-theme.zip"><img src="https://img.shields.io/badge/Mod_Labyrinth_Dark-1CD96A?style=for-the-badge&logo=github" alt="Mod Labyrinth Dark"></a>
   </summary>
-  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod.Labyrinth.Dark/preview.png" alt="Mod Labyrinth Dark theme preview">
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod%20Labyrinth%20Dark/preview.png" alt="Mod Labyrinth Dark theme preview">
 </details>
 <details class="theme-preview">
   <summary aria-label="Show screenshots">
     <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Mixed-theme.zip"><img src="https://img.shields.io/badge/Mod_Labyrinth_Mixed-1CD96A?style=for-the-badge&logo=github" alt="Mod Labyrinth Mixed"></a>
   </summary>
-  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod.Labyrinth.Mixed/preview.png" alt="Mod Labyrinth Mixed theme preview">
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod%20Labyrinth%20Mixed/preview.png" alt="Mod Labyrinth Mixed theme preview">
 </details>
 <details class="theme-preview">
   <summary aria-label="Show screenshots">
     <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Pale-theme.zip"><img src="https://img.shields.io/badge/Mod_Labyrinth_Pale-1CD96A?style=for-the-badge&logo=github" alt="Mod Labyrinth Pale"></a>
   </summary>
-  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod.Labyrinth.Pale/preview.png" alt="Mod Labyrinth Pale theme preview">
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod%20Labyrinth%20Pale/preview.png" alt="Mod Labyrinth Pale theme preview">
 </details>
 <details class="theme-preview">
   <summary aria-label="Show screenshots">

--- a/src/content/docs/wiki/getting-started/change-themes.md
+++ b/src/content/docs/wiki/getting-started/change-themes.md
@@ -183,8 +183,13 @@ Themes can help you spice up your launcher appearance.
 
 ### Icon Packs
 
-[![Fluent Dark Icons](https://img.shields.io/badge/Fluent--Icons-60CDFF?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Fluent-Dark-icons.zip)
-[![Twemoji Icon Pack](https://img.shields.io/badge/Twemoji--Icons-1d9bf0?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Twemoji-icons.zip)
+<a class="theme-preview-static" href="https://github.com/PrismLauncher/Themes/releases/latest/download/Fluent-Dark-icons.zip"><img src="https://img.shields.io/badge/Fluent--Icons-60CDFF?style=for-the-badge&logo=github&logoColor=333333" alt="Fluent Dark Icons"></a>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Twemoji-icons.zip"><img src="https://img.shields.io/badge/Twemoji--Icons-1d9bf0?style=for-the-badge&logo=github&logoColor=white" alt="Twemoji Icon Pack"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/icons/Twemoji/preview.png" alt="Twemoji icon pack preview">
+</details>
 
 ## How to install Themes & Icons
 

--- a/src/content/docs/wiki/getting-started/change-themes.md
+++ b/src/content/docs/wiki/getting-started/change-themes.md
@@ -12,34 +12,174 @@ Themes can help you spice up your launcher appearance.
 
 ### Themes
 
-[![Amoled](https://img.shields.io/badge/Amoled-000000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Amoled-theme.zip)
-[![BD Blue](https://img.shields.io/badge/BD_Blue-4989E6?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/BD-Blue-theme.zip)
-[![Borest](https://img.shields.io/badge/Borest-1E1E2E?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Borest-theme.zip)
-[![Breeze Dark](https://img.shields.io/badge/Breeze_Dark-blue?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Breeze-Dark-theme.zip)
-[![Cat](https://img.shields.io/badge/Cat-9F90B9?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Cat-theme.zip)
-[![Catppuccin Frappe](https://img.shields.io/badge/Catppuccin_Frappe-EF9F76?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Frappe-theme.zip)
-[![Catppuccin Latte](https://img.shields.io/badge/Catppuccin_Latte-DC8A78?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Latte-theme.zip)
-[![Catppuccin Macchiato](https://img.shields.io/badge/Catppuccin_Macchiato-A6DA95?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Macchiato-theme.zip)
-[![Catppuccin Mocha](https://img.shields.io/badge/Catppuccin_Mocha-DDB6F2?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Mocha-theme.zip)
-[![Deep Dark](https://img.shields.io/badge/Deep_Dark-141414?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Deep-Dark-theme.zip)
-[![Dracula](https://img.shields.io/badge/Dracula-BD93F9?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Dracula-theme.zip)
-[![Everforest Dark Hard](https://img.shields.io/badge/Everforest_Dark_Hard-3c4841?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Everforest-Dark-Hard-theme.zip)
-[![Everforest Medium](https://img.shields.io/badge/Everforest_Medium-425047?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Everforest-Medium-theme.zip)
-[![Fluent Dark](https://img.shields.io/badge/Fluent_Dark-60CDFF?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Fluent-Dark-theme.zip)
-[![Jvne](https://img.shields.io/badge/Jvne-7455FE?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Jvne-theme.zip)
-[![Kanagawa](https://img.shields.io/badge/Kanagawa-54546D?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Kanagawa-theme.zip)
-[![Mellow](https://img.shields.io/badge/Mellow-%23161617?style=for-the-badge&logo=github)](https://github.com/PrismLauncher/Themes/releases/latest/download/Mellow-theme.zip)
-[![Mod Labyrinth Dark](https://img.shields.io/badge/Mod_Labyrinth_Dark-1CD96A?style=for-the-badge&logo=github)](https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Dark-theme.zip)
-[![Mod Labyrinth Mixed](https://img.shields.io/badge/Mod_Labyrinth_Mixed-1CD96A?style=for-the-badge&logo=github)](https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Mixed-theme.zip)
-[![Mod Labyrinth Pale](https://img.shields.io/badge/Mod_Labyrinth_Pale-1CD96A?style=for-the-badge&logo=github)](https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Pale-theme.zip)
-[![Nord Polar Night](https://img.shields.io/badge/Nord_Polar_Night-4C566A?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Nord-Polar-Night-theme.zip)
-[![Nord Snow Storm](https://img.shields.io/badge/Nord_Snow_Storm-E5E9F0?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Nord-Snow-Storm-theme.zip)
-[![Nord](https://img.shields.io/badge/Nord-88C0D0?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Nord-theme.zip)
-[![Rangoon Lightning](https://img.shields.io/badge/Rangoon_Lightning-FFBF22?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Rangoon-Lightning-theme.zip)
-[![Scarlett Pink](https://img.shields.io/badge/Scarlett_Pink-F8C8DC?style=for-the-badge&logo=github&logoColor=900000)](https://github.com/PrismLauncher/Themes/releases/latest/download/Scarlett-Pink-theme.zip)
-[![Solarized Dark](https://img.shields.io/badge/Solarized_Dark-073642?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Solarized-Dark-theme.zip)
-[![Steam Classic](https://img.shields.io/badge/Steam_Classic-4C5844?style=for-the-badge&logo=github&logoColor=white)](https://github.com/PrismLauncher/Themes/releases/latest/download/Steam-Classic-theme.zip)
-[![Tokyo Night](https://img.shields.io/badge/Tokyo_Night-C0CAF5?style=for-the-badge&logo=github&logoColor=333333)](https://github.com/PrismLauncher/Themes/releases/latest/download/Tokyo-Night-theme.zip)
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Amoled-theme.zip"><img src="https://img.shields.io/badge/Amoled-000000?style=for-the-badge&logo=github&logoColor=white" alt="Amoled"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Amoled/preview.png" alt="Amoled theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/BD-Blue-theme.zip"><img src="https://img.shields.io/badge/BD_Blue-4989E6?style=for-the-badge&logo=github&logoColor=white" alt="BD Blue"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/BD-Blue/preview.png" alt="BD Blue theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Borest-theme.zip"><img src="https://img.shields.io/badge/Borest-1E1E2E?style=for-the-badge&logo=github&logoColor=white" alt="Borest"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Borest/preview.png" alt="Borest theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Breeze-Dark-theme.zip"><img src="https://img.shields.io/badge/Breeze_Dark-blue?style=for-the-badge&logo=github&logoColor=white" alt="Breeze Dark"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Breeze-Dark/preview.png" alt="Breeze Dark theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Cat-theme.zip"><img src="https://img.shields.io/badge/Cat-9F90B9?style=for-the-badge&logo=github&logoColor=white" alt="Cat"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Cat/preview.png" alt="Cat theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Frappe-theme.zip"><img src="https://img.shields.io/badge/Catppuccin_Frappe-EF9F76?style=for-the-badge&logo=github&logoColor=333333" alt="Catppuccin Frappe"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Catppuccin-Frappe/preview.png" alt="Catppuccin Frappe theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Latte-theme.zip"><img src="https://img.shields.io/badge/Catppuccin_Latte-DC8A78?style=for-the-badge&logo=github&logoColor=white" alt="Catppuccin Latte"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Catppuccin-Latte/preview.png" alt="Catppuccin Latte theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Macchiato-theme.zip"><img src="https://img.shields.io/badge/Catppuccin_Macchiato-A6DA95?style=for-the-badge&logo=github&logoColor=333333" alt="Catppuccin Macchiato"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Catppuccin-Macchiato/preview.png" alt="Catppuccin Macchiato theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Catppuccin-Mocha-theme.zip"><img src="https://img.shields.io/badge/Catppuccin_Mocha-DDB6F2?style=for-the-badge&logo=github&logoColor=333333" alt="Catppuccin Mocha"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Catppuccin-Mocha/preview.png" alt="Catppuccin Mocha theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Deep-Dark-theme.zip"><img src="https://img.shields.io/badge/Deep_Dark-141414?style=for-the-badge&logo=github&logoColor=white" alt="Deep Dark"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Deep-Dark/preview.png" alt="Deep Dark theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Dracula-theme.zip"><img src="https://img.shields.io/badge/Dracula-BD93F9?style=for-the-badge&logo=github&logoColor=white" alt="Dracula"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Dracula/preview.png" alt="Dracula theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Everforest-Dark-Hard-theme.zip"><img src="https://img.shields.io/badge/Everforest_Dark_Hard-3c4841?style=for-the-badge&logo=github&logoColor=white" alt="Everforest Dark Hard"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Everforest-Dark-Hard/preview.png" alt="Everforest Dark Hard theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Everforest-Medium-theme.zip"><img src="https://img.shields.io/badge/Everforest_Medium-425047?style=for-the-badge&logo=github&logoColor=white" alt="Everforest Medium"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Everforest-Medium/preview.png" alt="Everforest Medium theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Fluent-Dark-theme.zip"><img src="https://img.shields.io/badge/Fluent_Dark-60CDFF?style=for-the-badge&logo=github&logoColor=333333" alt="Fluent Dark"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Fluent-Dark/preview.png" alt="Fluent Dark theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Jvne-theme.zip"><img src="https://img.shields.io/badge/Jvne-7455FE?style=for-the-badge&logo=github&logoColor=white" alt="Jvne"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Jvne/preview.png" alt="Jvne theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Kanagawa-theme.zip"><img src="https://img.shields.io/badge/Kanagawa-54546D?style=for-the-badge&logo=github&logoColor=white" alt="Kanagawa"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Kanagawa/preview.png" alt="Kanagawa theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mellow-theme.zip"><img src="https://img.shields.io/badge/Mellow-%23161617?style=for-the-badge&logo=github" alt="Mellow"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mellow/preview.png" alt="Mellow theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Dark-theme.zip"><img src="https://img.shields.io/badge/Mod_Labyrinth_Dark-1CD96A?style=for-the-badge&logo=github" alt="Mod Labyrinth Dark"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod.Labyrinth.Dark/preview.png" alt="Mod Labyrinth Dark theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Mixed-theme.zip"><img src="https://img.shields.io/badge/Mod_Labyrinth_Mixed-1CD96A?style=for-the-badge&logo=github" alt="Mod Labyrinth Mixed"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod.Labyrinth.Mixed/preview.png" alt="Mod Labyrinth Mixed theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Mod.Labyrinth.Pale-theme.zip"><img src="https://img.shields.io/badge/Mod_Labyrinth_Pale-1CD96A?style=for-the-badge&logo=github" alt="Mod Labyrinth Pale"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Mod.Labyrinth.Pale/preview.png" alt="Mod Labyrinth Pale theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Nord-Polar-Night-theme.zip"><img src="https://img.shields.io/badge/Nord_Polar_Night-4C566A?style=for-the-badge&logo=github&logoColor=white" alt="Nord Polar Night"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Nord-Polar-Night/preview.png" alt="Nord Polar Night theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Nord-Snow-Storm-theme.zip"><img src="https://img.shields.io/badge/Nord_Snow_Storm-E5E9F0?style=for-the-badge&logo=github&logoColor=333333" alt="Nord Snow Storm"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Nord-Snow-Storm/preview.png" alt="Nord Snow Storm theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Nord-theme.zip"><img src="https://img.shields.io/badge/Nord-88C0D0?style=for-the-badge&logo=github&logoColor=white" alt="Nord"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Nord/preview.png" alt="Nord theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Rangoon-Lightning-theme.zip"><img src="https://img.shields.io/badge/Rangoon_Lightning-FFBF22?style=for-the-badge&logo=github&logoColor=333333" alt="Rangoon Lightning"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Rangoon-Lightning/preview.png" alt="Rangoon Lightning theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Scarlett-Pink-theme.zip"><img src="https://img.shields.io/badge/Scarlett_Pink-F8C8DC?style=for-the-badge&logo=github&logoColor=900000" alt="Scarlett Pink"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Scarlett-Pink/preview.png" alt="Scarlett Pink theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Solarized-Dark-theme.zip"><img src="https://img.shields.io/badge/Solarized_Dark-073642?style=for-the-badge&logo=github&logoColor=white" alt="Solarized Dark"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Solarized-Dark/preview.png" alt="Solarized Dark theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Steam-Classic-theme.zip"><img src="https://img.shields.io/badge/Steam_Classic-4C5844?style=for-the-badge&logo=github&logoColor=white" alt="Steam Classic"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Steam-Classic/preview.png" alt="Steam Classic theme preview">
+</details>
+<details class="theme-preview">
+  <summary aria-label="Show screenshots">
+    <a href="https://github.com/PrismLauncher/Themes/releases/latest/download/Tokyo-Night-theme.zip"><img src="https://img.shields.io/badge/Tokyo_Night-C0CAF5?style=for-the-badge&logo=github&logoColor=333333" alt="Tokyo Night"></a>
+  </summary>
+  <img src="https://raw.githubusercontent.com/PrismLauncher/Themes/main/themes/Tokyo-Night/preview.png" alt="Tokyo Night theme preview">
+</details>
 
 ### Icon Packs
 

--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -40,3 +40,8 @@
 	max-width: 100%;
 	height: auto;
 }
+
+.theme-preview-static {
+	display: inline-block;
+	margin-left: 1.75rem;
+}

--- a/src/styles/starlight.css
+++ b/src/styles/starlight.css
@@ -19,3 +19,24 @@
 	--sl-color-text: #ffffff;
 	--sl-color-bg: #15181c;
 }
+
+.theme-preview {
+	border: none;
+	padding: 0;
+	max-width: 100%;
+}
+
+.theme-preview summary {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	padding: 0;
+	list-style: none;
+}
+
+.theme-preview > img {
+	display: block;
+	width: 700px;
+	max-width: 100%;
+	height: auto;
+}


### PR DESCRIPTION
The Wiki provides an easy way to download themes without ever viewing GitHub, but it doesn't provide screenshots. This fix adds a dropdown for each theme, letting users view theme screenshots without leaving the Wiki.

<img width="1512" height="812" alt="theme screenshots" src="https://github.com/user-attachments/assets/96a85425-f6a8-4abf-8360-b3e06ab35345" />